### PR TITLE
Sam device

### DIFF
--- a/nvme/src/info.rs
+++ b/nvme/src/info.rs
@@ -88,8 +88,7 @@ fn device_name(device: &str) -> &str {
 
 /// Retrieves ZNS configuration and metadata for a device by opening it and querying its properties.
 /// Returns a `ZNSConfig` struct on success or an `NVMeError` on failure.
-pub fn zns_get_info(device: &str) -> Result<ZNSConfig, NVMeError> {
-    // Trim the device name so that it's only the filename after /dev/
+// Trim the device name so that it's only the filename after /dev/
 pub fn nvme_get_info(device: &str) -> Result<NVMeConfig, NVMeError> {
     let device_name_ = device_name(device);
     let fd: RawFd = match open_device(device_name_) {

--- a/nvme/src/info.rs
+++ b/nvme/src/info.rs
@@ -140,6 +140,7 @@ pub fn nvme_get_info(device: &str) -> Result<NVMeConfig, NVMeError> {
         total_size_in_bytes,
         current_lba_index,
         lba_perf: 0,
+        timeout: 0, // Unimplemented
     })
 }
 
@@ -178,7 +179,6 @@ pub fn zns_get_info(nvme_config: &NVMeConfig) -> Result<ZNSConfig, NVMeError> {
         zasl: zasl,
         zone_descriptor_extension_size: zdesc_ext_size,
         zone_size: zone_size,
-        timeout: 0,
         chunks_per_zone: 0,
         chunk_size: 0,
     })
@@ -270,11 +270,16 @@ pub fn report_zones(
 
 pub fn is_zoned_device(device: &str) -> Result<bool, io::Error> {
     let device_name_ = device_name(device);
-    
+
     let zoned = fs::read_to_string(format!("/sys/block/{}/queue/zoned", device_name_))?;
     match zoned.as_str() {
         "host-managed" => Ok(true),
         "host-aware" => Ok(true),
         _ => Ok(false),
     }
+}
+
+/// Zone size is in logical blocks
+pub fn get_address_at(zone_index: u64, chunk_index: u64, zone_size: u64, chunk_size: u64) -> u64 {
+    zone_size * zone_index + chunk_index * chunk_size
 }

--- a/nvme/src/types.rs
+++ b/nvme/src/types.rs
@@ -48,6 +48,7 @@ pub struct NVMeConfig {
     pub total_size_in_bytes: u64,
     pub current_lba_index: usize,
     pub lba_perf: u64, // Unimplemented
+    pub timeout: u32,  // Default 0
 }
 
 // Assumes that the zone capacity is the same for every zone
@@ -64,16 +65,19 @@ pub struct ZNSConfig {
     pub zone_size: u64,                      // This is in number of logical blocks
 
     pub chunks_per_zone: u64, // Number of chunks that can be allocated in a zone
-    pub chunk_size: usize,
+    pub chunk_size: usize,    // This is in logical blocks
 
     pub num_zones: u64,
-    pub timeout: u32, // Default 0
 }
 
 impl ZNSConfig {
     // The ZSLBA field is referenced in logical blocks
     pub fn get_starting_addr(&self, zone_index: u64) -> u64 {
         self.zone_size * zone_index
+    }
+
+    pub fn get_address_at(&self, zone_index: u64, chunk_index: u64) -> u64 {
+        self.zone_size * zone_index + chunk_index * self.chunk_size as u64
     }
 }
 

--- a/nvme/src/types.rs
+++ b/nvme/src/types.rs
@@ -1,4 +1,9 @@
-use std::{convert::Infallible, fmt::{self, Debug, Display}, io, os::fd::RawFd};
+use std::{
+    convert::Infallible,
+    fmt::{self, Debug, Display},
+    io,
+    os::fd::RawFd,
+};
 
 use errno::Errno;
 use libnvme_sys::bindings::nvme_status_result;
@@ -35,46 +40,48 @@ impl TryFrom<u8> for ZoneState {
     }
 }
 
+#[derive(Debug)]
+pub struct NVMeConfig {
+    pub fd: RawFd,
+    pub nsid: u32,
+    pub logical_block_size: u64,
+    pub total_size_in_bytes: u64,
+    pub current_lba_index: usize,
+    pub lba_perf: u64, // Unimplemented
+}
+
 // Assumes that the zone capacity is the same for every zone
 /// Holds configuration and metadata for a ZNS (Zoned Namespace) device.
 #[derive(Debug)]
 pub struct ZNSConfig {
-    pub fd: RawFd,
-    pub nsid: u32,
-
-    // This are per-namespace, not the entire drive
-    pub total_size_in_bytes: u64,
-    pub total_size_in_lbs: u64,
-	// These are 1-based, unlike what is returned in libnvme
+    // These are 1-based, unlike what is returned in libnvme
     pub max_active_resources: u32, // Open and closed zones
     pub max_open_resources: u32,   // Just open zones
 
     // These are per-controller
     pub zasl: u32, // The zone append size limit. Max append size is zasl bytes.
     pub zone_descriptor_extension_size: u64, // The size of the data that can be associated with a zone, in bytes
-    pub block_size: u64,                       // In bytes
     pub zone_size: u64,                      // This is in number of logical blocks
 
     pub chunks_per_zone: u64, // Number of chunks that can be allocated in a zone
     pub chunk_size: usize,
 
     pub num_zones: u64,
-    pub timeout: u32,  // Default 0
-    pub lba_perf: u64, // Unimplemented
+    pub timeout: u32, // Default 0
 }
 
 impl ZNSConfig {
-
-	// The ZSLBA field is referenced in logical blocks
-	pub fn get_starting_addr(&self, zone_index: u64) -> u64 {
-		self.zone_size * zone_index
-	}
+    // The ZSLBA field is referenced in logical blocks
+    pub fn get_starting_addr(&self, zone_index: u64) -> u64 {
+        self.zone_size * zone_index
+    }
 }
 
 /// Specifies which zones to perform an operation on (all or a specific zone).
 #[derive(PartialEq)]
 pub enum PerformOn {
-	AllZones, Zone(u64)
+    AllZones,
+    Zone(u64),
 }
 
 /// Describes the properties and state of a single ZNS (Zoned Namespace) zone.
@@ -117,8 +124,14 @@ pub struct ZNSZoneDescriptor {
 pub enum NVMeError {
     Errno(Errno),
     StatusResult(nvme_status_result),
-    UnalignedDataBuffer { want: u64, has: u64 },
-	AppendSizeTooLarge { max_append: u32, trying_to_append: u32 },
+    UnalignedDataBuffer {
+        want: u64,
+        has: u64,
+    },
+    AppendSizeTooLarge {
+        max_append: u32,
+        trying_to_append: u32,
+    },
 }
 
 impl fmt::Display for NVMeError {
@@ -127,11 +140,24 @@ impl fmt::Display for NVMeError {
             f,
             "{}",
             match self {
-                NVMeError::Errno(errno)=>format!("Error: errno {}: {}",errno.0,errno),
-				NVMeError::StatusResult(res)=>format!("Error: NVMe Status Result {}: {}",res,get_error_string(*res)),
-				NVMeError::UnalignedDataBuffer{want,has}=>format!("Unaligned data buffer: want buffer size of multiple {} but got size {}",want,has),
-				NVMeError::AppendSizeTooLarge{max_append,trying_to_append}=>format!("Append size too large: max append is {} bytes while trying to append {} bytes",max_append,trying_to_append),
-							}
+                NVMeError::Errno(errno) => format!("Error: errno {}: {}", errno.0, errno),
+                NVMeError::StatusResult(res) => format!(
+                    "Error: NVMe Status Result {}: {}",
+                    res,
+                    get_error_string(*res)
+                ),
+                NVMeError::UnalignedDataBuffer { want, has } => format!(
+                    "Unaligned data buffer: want buffer size of multiple {} but got size {}",
+                    want, has
+                ),
+                NVMeError::AppendSizeTooLarge {
+                    max_append,
+                    trying_to_append,
+                } => format!(
+                    "Append size too large: max append is {} bytes while trying to append {} bytes",
+                    max_append, trying_to_append
+                ),
+            }
         )
     }
 }
@@ -145,7 +171,10 @@ impl TryFrom<NVMeError> for std::io::Error {
         match value {
             NVMeError::Errno(errno) => Ok(io::Error::from_raw_os_error(errno.0)),
             NVMeError::StatusResult(status) => Ok(io::Error::other(get_error_string(status))),
-            _ => Ok(io::Error::new(io::ErrorKind::InvalidInput, format!("{}", value))),
+            _ => Ok(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("{}", value),
+            )),
         }
     }
 }

--- a/nvme/src/util.rs
+++ b/nvme/src/util.rs
@@ -1,4 +1,8 @@
-use std::{ffi::{c_void, CStr}, ops::{BitAnd, Shr}, ptr::null};
+use std::{
+    ffi::{CStr, c_void},
+    ops::{BitAnd, Shr},
+    ptr::null,
+};
 
 use errno::errno;
 use libnvme_sys::bindings::{
@@ -129,7 +133,7 @@ pub fn shift_and_mask<ToShift, ShiftAs, Result>(
 ) -> Result
 where
     ToShift: Into<ShiftAs>,
-    ShiftAs: Shr<ShiftAs, Output=ShiftAs> + BitAnd<ShiftAs, Output = ShiftAs> + Into<Result>,
+    ShiftAs: Shr<ShiftAs, Output = ShiftAs> + BitAnd<ShiftAs, Output = ShiftAs> + Into<Result>,
 {
     ((to_shift.into() >> shift) & mask).into()
 }

--- a/nvme/tests/lib-tests.rs
+++ b/nvme/tests/lib-tests.rs
@@ -33,7 +33,8 @@ fn test_config(nvme_config: &NVMeConfig, config: &ZNSConfig) {
 }
 
 fn test_append(nvme_config: &NVMeConfig, config: &ZNSConfig) {
-    reset_zone(nvme_config, config, nvme::types::PerformOn::AllZones).expect("Failed to reset zones");
+    reset_zone(nvme_config, config, nvme::types::PerformOn::AllZones)
+        .expect("Failed to reset zones");
 
     let string = "hello world. this is a test\n".as_bytes();
     let mut buf = vec![0_u8; nvme_config.logical_block_size as usize];
@@ -51,7 +52,8 @@ fn test_append(nvme_config: &NVMeConfig, config: &ZNSConfig) {
 }
 
 fn test_append_multiple_zones(nvme_config: &NVMeConfig, config: &ZNSConfig) {
-    reset_zone(nvme_config, config, nvme::types::PerformOn::AllZones).expect("Failed to reset zones");
+    reset_zone(nvme_config, config, nvme::types::PerformOn::AllZones)
+        .expect("Failed to reset zones");
 
     let string = "hello world. this is a test\n".as_bytes();
     let mut buf = vec![0_u8; nvme_config.logical_block_size as usize];
@@ -75,7 +77,8 @@ fn test_append_multiple_zones(nvme_config: &NVMeConfig, config: &ZNSConfig) {
 }
 
 fn test_append_offset(nvme_config: &NVMeConfig, config: &ZNSConfig) {
-    reset_zone(nvme_config, config, nvme::types::PerformOn::AllZones).expect("Failed to reset zones");
+    reset_zone(nvme_config, config, nvme::types::PerformOn::AllZones)
+        .expect("Failed to reset zones");
 
     let string = "hello world. this is a test\n".as_bytes();
     let mut buf = vec![0_u8; nvme_config.logical_block_size as usize];
@@ -108,7 +111,8 @@ fn test_append_offset(nvme_config: &NVMeConfig, config: &ZNSConfig) {
 }
 
 fn test_reset_zone(nvme_config: &NVMeConfig, config: &ZNSConfig) {
-    reset_zone(nvme_config, config, nvme::types::PerformOn::AllZones).expect("Failed to reset all zones");
+    reset_zone(nvme_config, config, nvme::types::PerformOn::AllZones)
+        .expect("Failed to reset all zones");
 
     let string = "hello world. this is a test\n".as_bytes();
     let mut buf = vec![0_u8; nvme_config.logical_block_size as usize];
@@ -118,8 +122,10 @@ fn test_reset_zone(nvme_config: &NVMeConfig, config: &ZNSConfig) {
     zns_append(nvme_config, config, 1, &mut buf).expect("Failed to append");
     zns_append(nvme_config, config, 2, &mut buf).expect("Failed to append");
 
-    reset_zone(nvme_config, config, nvme::types::PerformOn::Zone(0)).expect("Failed to reset zone 1");
-    reset_zone(nvme_config, config, nvme::types::PerformOn::Zone(2)).expect("Failed to reset zone 2");
+    reset_zone(nvme_config, config, nvme::types::PerformOn::Zone(0))
+        .expect("Failed to reset zone 1");
+    reset_zone(nvme_config, config, nvme::types::PerformOn::Zone(2))
+        .expect("Failed to reset zone 2");
 
     let empty_buf = vec![0_u8; nvme_config.logical_block_size as usize];
     let mut read_buf = vec![0_u8; nvme_config.logical_block_size as usize];

--- a/nvme/tests/lib-tests.rs
+++ b/nvme/tests/lib-tests.rs
@@ -1,6 +1,6 @@
-use nvme::info::zns_get_info;
-use nvme::ops::{reset_zone, zns_append, zns_open, zns_read};
-use nvme::types::ZNSConfig;
+use nvme::info::{nvme_get_info, zns_get_info};
+use nvme::ops::{open_device, reset_zone, zns_append, zns_read};
+use nvme::types::{NVMeConfig, ZNSConfig};
 use std::path::PathBuf;
 use std::{fs::File, io::Read};
 use toml::{self, Table};
@@ -17,110 +17,120 @@ fn init() {
     let table = buffer.parse::<Table>().unwrap();
     let zns_device = table["zns"].as_str().unwrap();
 
-    let config = zns_get_info(zns_device).expect("Couldn't open device");
+    let nvme_config = nvme_get_info(zns_device).expect("Couldn't open NVMe device");
+    let config = zns_get_info(&nvme_config).expect("Couldn't open ZNS device");
 
-    test_config(&config);
-
-    test_append(&config);
-    test_append_multiple_zones(&config);
-    test_append_offset(&config);
-    test_reset_zone(&config);
+    test_config(&nvme_config, &config);
+    test_append(&nvme_config, &config);
+    test_append_multiple_zones(&nvme_config, &config);
+    test_append_offset(&nvme_config, &config);
+    test_reset_zone(&nvme_config, &config);
 }
 
-fn test_config(config: &ZNSConfig) {
+fn test_config(nvme_config: &NVMeConfig, config: &ZNSConfig) {
+    println!("{:?}", nvme_config);
     println!("{:?}", config);
 }
 
-fn test_append(config: &ZNSConfig) {
-    reset_zone(config, nvme::types::PerformOn::AllZones).expect("Failed to reset zones");
+fn test_append(nvme_config: &NVMeConfig, config: &ZNSConfig) {
+    reset_zone(nvme_config, config, nvme::types::PerformOn::AllZones).expect("Failed to reset zones");
 
     let string = "hello world. this is a test\n".as_bytes();
-    let mut buf = vec![0_u8; config.block_size as usize];
+    let mut buf = vec![0_u8; nvme_config.logical_block_size as usize];
     buf[..string.len()].clone_from_slice(&string);
 
-    zns_append(config, 0, &mut buf).expect("Failed to append");
-    zns_append(config, 0, &mut buf).expect("Failed to append");
-    zns_append(config, 0, &mut buf).expect("Failed to append");
+    zns_append(nvme_config, config, 0, &mut buf).expect("Failed to append");
+    zns_append(nvme_config, config, 0, &mut buf).expect("Failed to append");
+    zns_append(nvme_config, config, 0, &mut buf).expect("Failed to append");
 
-    let mut read_buf = vec![0_u8; config.block_size as usize];
+    let mut read_buf = vec![0_u8; nvme_config.logical_block_size as usize];
 
-    zns_read(config, 0, 0, &mut read_buf).expect("Failed to read");
+    zns_read(nvme_config, config, 0, 0, &mut read_buf).expect("Failed to read");
 
     assert_eq!(buf, read_buf);
 }
 
-fn test_append_multiple_zones(config: &ZNSConfig) {
-    reset_zone(config, nvme::types::PerformOn::AllZones).expect("Failed to reset zones");
+fn test_append_multiple_zones(nvme_config: &NVMeConfig, config: &ZNSConfig) {
+    reset_zone(nvme_config, config, nvme::types::PerformOn::AllZones).expect("Failed to reset zones");
 
     let string = "hello world. this is a test\n".as_bytes();
-    let mut buf = vec![0_u8; config.block_size as usize];
+    let mut buf = vec![0_u8; nvme_config.logical_block_size as usize];
     buf[..string.len()].clone_from_slice(&string);
 
-    zns_append(config, 0, &mut buf).expect("Failed to append");
-    zns_append(config, 1, &mut buf).expect("Failed to append");
-    zns_append(config, 2, &mut buf).expect("Failed to append");
+    zns_append(nvme_config, config, 0, &mut buf).expect("Failed to append");
+    zns_append(nvme_config, config, 1, &mut buf).expect("Failed to append");
+    zns_append(nvme_config, config, 2, &mut buf).expect("Failed to append");
 
-    let mut read_buf = vec![0_u8; config.block_size as usize];
-    zns_read(config, 0, 0, &mut read_buf).expect("Failed to read");
+    let mut read_buf = vec![0_u8; nvme_config.logical_block_size as usize];
+    zns_read(nvme_config, config, 0, 0, &mut read_buf).expect("Failed to read");
     assert_eq!(buf, read_buf);
 
-    let mut read_buf = vec![0_u8; config.block_size as usize];
-    zns_read(config, 1, 0, &mut read_buf).expect("Failed to read");
+    let mut read_buf = vec![0_u8; nvme_config.logical_block_size as usize];
+    zns_read(nvme_config, config, 1, 0, &mut read_buf).expect("Failed to read");
     assert_eq!(buf, read_buf);
 
-    let mut read_buf = vec![0_u8; config.block_size as usize];
-    zns_read(config, 2, 0, &mut read_buf).expect("Failed to read");
+    let mut read_buf = vec![0_u8; nvme_config.logical_block_size as usize];
+    zns_read(nvme_config, config, 2, 0, &mut read_buf).expect("Failed to read");
     assert_eq!(buf, read_buf);
 }
 
-fn test_append_offset(config: &ZNSConfig) {
-    reset_zone(config, nvme::types::PerformOn::AllZones).expect("Failed to reset zones");
+fn test_append_offset(nvme_config: &NVMeConfig, config: &ZNSConfig) {
+    reset_zone(nvme_config, config, nvme::types::PerformOn::AllZones).expect("Failed to reset zones");
 
     let string = "hello world. this is a test\n".as_bytes();
-    let mut buf = vec![0_u8; config.block_size as usize];
+    let mut buf = vec![0_u8; nvme_config.logical_block_size as usize];
     buf[..string.len()].clone_from_slice(&string);
 
-    assert_eq!(zns_append(config, 0, &mut buf).expect("Failed to append"), 0);
-    assert_eq!(zns_append(config, 0, &mut buf).expect("Failed to append"), 1);
-    assert_eq!(zns_append(config, 0, &mut buf).expect("Failed to append"), 2);
+    assert_eq!(
+        zns_append(nvme_config, config, 0, &mut buf).expect("Failed to append"),
+        0
+    );
+    assert_eq!(
+        zns_append(nvme_config, config, 0, &mut buf).expect("Failed to append"),
+        1
+    );
+    assert_eq!(
+        zns_append(nvme_config, config, 0, &mut buf).expect("Failed to append"),
+        2
+    );
 
-    let mut read_buf = vec![0_u8; config.block_size as usize];
-    zns_read(config, 0, 0, &mut read_buf).expect("Failed to read");
+    let mut read_buf = vec![0_u8; nvme_config.logical_block_size as usize];
+    zns_read(nvme_config, config, 0, 0, &mut read_buf).expect("Failed to read");
     assert_eq!(buf, read_buf);
 
-    let mut read_buf = vec![0_u8; config.block_size as usize];
-    zns_read(config, 0, 1, &mut read_buf).expect("Failed to read");
+    let mut read_buf = vec![0_u8; nvme_config.logical_block_size as usize];
+    zns_read(nvme_config, config, 0, 1, &mut read_buf).expect("Failed to read");
     assert_eq!(buf, read_buf);
 
-    let mut read_buf = vec![0_u8; config.block_size as usize];
-    zns_read(config, 0, 2, &mut read_buf).expect("Failed to read");
+    let mut read_buf = vec![0_u8; nvme_config.logical_block_size as usize];
+    zns_read(nvme_config, config, 0, 2, &mut read_buf).expect("Failed to read");
     assert_eq!(buf, read_buf);
 }
 
-fn test_reset_zone(config: &ZNSConfig) {
-    reset_zone(config, nvme::types::PerformOn::AllZones).expect("Failed to reset all zones");
+fn test_reset_zone(nvme_config: &NVMeConfig, config: &ZNSConfig) {
+    reset_zone(nvme_config, config, nvme::types::PerformOn::AllZones).expect("Failed to reset all zones");
 
     let string = "hello world. this is a test\n".as_bytes();
-    let mut buf = vec![0_u8; config.block_size as usize];
+    let mut buf = vec![0_u8; nvme_config.logical_block_size as usize];
     buf[..string.len()].clone_from_slice(&string);
 
-    zns_append(config, 0, &mut buf).expect("Failed to append");
-    zns_append(config, 1, &mut buf).expect("Failed to append");
-    zns_append(config, 2, &mut buf).expect("Failed to append");
+    zns_append(nvme_config, config, 0, &mut buf).expect("Failed to append");
+    zns_append(nvme_config, config, 1, &mut buf).expect("Failed to append");
+    zns_append(nvme_config, config, 2, &mut buf).expect("Failed to append");
 
-    reset_zone(config, nvme::types::PerformOn::Zone(0)).expect("Failed to reset zone 1");    
-    reset_zone(config, nvme::types::PerformOn::Zone(2)).expect("Failed to reset zone 2");    
+    reset_zone(nvme_config, config, nvme::types::PerformOn::Zone(0)).expect("Failed to reset zone 1");
+    reset_zone(nvme_config, config, nvme::types::PerformOn::Zone(2)).expect("Failed to reset zone 2");
 
-    let empty_buf = vec![0_u8; config.block_size as usize];
-    let mut read_buf = vec![0_u8; config.block_size as usize];
-    zns_read(config, 0, 0, &mut read_buf).expect("Failed to read");
+    let empty_buf = vec![0_u8; nvme_config.logical_block_size as usize];
+    let mut read_buf = vec![0_u8; nvme_config.logical_block_size as usize];
+    zns_read(nvme_config, config, 0, 0, &mut read_buf).expect("Failed to read");
     assert_eq!(empty_buf, read_buf);
 
-    let mut read_buf = vec![0_u8; config.block_size as usize];
-    zns_read(config, 1, 0, &mut read_buf).expect("Failed to read");
+    let mut read_buf = vec![0_u8; nvme_config.logical_block_size as usize];
+    zns_read(nvme_config, config, 1, 0, &mut read_buf).expect("Failed to read");
     assert_eq!(buf, read_buf);
 
-    let mut read_buf = vec![0_u8; config.block_size as usize];
-    zns_read(config, 2, 0, &mut read_buf).expect("Failed to read");
+    let mut read_buf = vec![0_u8; nvme_config.logical_block_size as usize];
+    zns_read(nvme_config, config, 2, 0, &mut read_buf).expect("Failed to read");
     assert_eq!(empty_buf, read_buf);
 }

--- a/oxcache/src/cache/bucket.rs
+++ b/oxcache/src/cache/bucket.rs
@@ -15,7 +15,7 @@ pub struct Chunk {
 #[derive(Clone)]
 pub struct ChunkLocation {
     pub zone: usize,
-    pub addr: u64,
+    pub addr: u64, // The chunk index
 }
 
 impl ChunkLocation {

--- a/oxcache/src/device.rs
+++ b/oxcache/src/device.rs
@@ -1,4 +1,4 @@
-use nvme::info::{is_zoned_device, nvme_get_info};
+use nvme::info::{get_address_at, is_zoned_device, nvme_get_info};
 use nvme::ops::{zns_append, zns_read};
 use nvme::types::{NVMeConfig, ZNSConfig};
 use std::collections::VecDeque;
@@ -141,13 +141,17 @@ pub struct BlockInterface {
     chunks_per_zone: usize,
     num_zones: usize,
     state: Arc<Mutex<BlockDeviceState>>,
-    evict_policy: Arc<Mutex<EvictionPolicyWrapper>>
+    evict_policy: Arc<Mutex<EvictionPolicyWrapper>>,
 }
 
 pub trait Device: Send + Sync {
     fn append(&self, data: Vec<u8>) -> std::io::Result<ChunkLocation>;
 
-    fn new(device: &str, chunk_size: usize, eviction_policy: Arc<Mutex<EvictionPolicyWrapper>>) -> std::io::Result<Self>
+    fn new(
+        device: &str,
+        chunk_size: usize,
+        eviction_policy: Arc<Mutex<EvictionPolicyWrapper>>,
+    ) -> std::io::Result<Self>
     where
         Self: Sized; // Args
 
@@ -162,13 +166,24 @@ pub trait Device: Send + Sync {
     fn read(&self, location: ChunkLocation) -> std::io::Result<Vec<u8>>;
 }
 
-
-pub fn get_device(device: &str, chunk_size: usize, eviction_policy: Arc<Mutex<EvictionPolicyWrapper>>) -> std::io::Result<Arc<dyn Device>> {
+pub fn get_device(
+    device: &str,
+    chunk_size: usize,
+    eviction_policy: Arc<Mutex<EvictionPolicyWrapper>>,
+) -> std::io::Result<Arc<dyn Device>> {
     let is_zoned = is_zoned_device(device)?;
     if is_zoned {
-        Ok(Arc::new(device::Zoned::new(device, chunk_size, eviction_policy)?))
+        Ok(Arc::new(device::Zoned::new(
+            device,
+            chunk_size,
+            eviction_policy,
+        )?))
     } else {
-        Ok(Arc::new(device::BlockInterface::new(device, chunk_size, eviction_policy)?))
+        Ok(Arc::new(device::BlockInterface::new(
+            device,
+            chunk_size,
+            eviction_policy,
+        )?))
     }
 }
 
@@ -188,14 +203,17 @@ impl Zoned {
 
 impl Device for Zoned {
     /// Hold internal state to keep track of zone state
-    fn new(device: &str, chunk_size: usize, eviction_policy: Arc<Mutex<EvictionPolicyWrapper>>) -> std::io::Result<Self> {
+    fn new(
+        device: &str,
+        chunk_size: usize,
+        eviction_policy: Arc<Mutex<EvictionPolicyWrapper>>,
+    ) -> std::io::Result<Self> {
         let nvme_config = match nvme::info::nvme_get_info(device) {
             Ok(config) => config,
             Err(err) => return Err(err.try_into().unwrap()),
         };
 
         match nvme::info::zns_get_info(&nvme_config) {
-
             Ok(mut config) => {
                 config.chunks_per_zone = config.zone_size / chunk_size as u64;
                 config.chunk_size = chunk_size;
@@ -223,11 +241,15 @@ impl Device for Zoned {
             mut_data.as_mut_slice(),
         ) {
             Ok(lba) => {
+                let chunk = lba / self.config.chunk_size as u64;
+
                 let mtx = Arc::clone(&self.evict_policy);
                 let policy = mtx.lock().unwrap();
-                policy.write_update(ChunkLocation::new(zone_index, lba)); // TODO: LBA correct?
+                policy.write_update(ChunkLocation::new(
+                    zone_index, chunk, // addr should be in chunks
+                ));
 
-                Ok(ChunkLocation::new(zone_index, lba))
+                Ok(ChunkLocation::new(zone_index, chunk))
             }
             Err(err) => Err(err.try_into().unwrap()),
         }
@@ -268,23 +290,19 @@ impl Device for Zoned {
         let mtx = Arc::clone(&self.evict_policy);
         let policy = mtx.lock().unwrap();
         match &*policy {
-            EvictionPolicyWrapper::Dummy(p) => {
-                Ok(())
-            },
+            EvictionPolicyWrapper::Dummy(p) => Ok(()),
             EvictionPolicyWrapper::Chunk(p) => {
                 unimplemented!()
-            },
-            EvictionPolicyWrapper::Promotional(p) => {
-                match p.get_evict_targets() {
-                    Some(evict_targets) => {
-                        let zone_mtx = Arc::clone(&self.zones);
-                        let mut zones = zone_mtx.lock().unwrap();
-                        zones.reset_zones(evict_targets);
-                        Ok(())
-                    }
-                    None => Err(Error::new(std::io::ErrorKind::Other, "No items to evict")),
-                }
             }
+            EvictionPolicyWrapper::Promotional(p) => match p.get_evict_targets() {
+                Some(evict_targets) => {
+                    let zone_mtx = Arc::clone(&self.zones);
+                    let mut zones = zone_mtx.lock().unwrap();
+                    zones.reset_zones(evict_targets);
+                    Ok(())
+                }
+                None => Err(Error::new(std::io::ErrorKind::Other, "No items to evict")),
+            },
         }
     }
 }
@@ -296,10 +314,12 @@ impl BlockInterface {
 }
 
 impl Device for BlockInterface {
-
     /// Hold internal state to keep track of "ssd" zone state
-    fn new(device: &str, chunk_size: usize, eviction_policy: Arc<Mutex<EvictionPolicyWrapper>>) -> std::io::Result<Self> {
-
+    fn new(
+        device: &str,
+        chunk_size: usize,
+        eviction_policy: Arc<Mutex<EvictionPolicyWrapper>>,
+    ) -> std::io::Result<Self> {
         let nvme_config = match nvme::info::nvme_get_info(device) {
             Ok(config) => config,
             Err(err) => return Err(err.try_into().unwrap()),
@@ -340,16 +360,21 @@ impl Device for BlockInterface {
 
         let mut mut_data = Vec::clone(&data);
 
-
         match nvme::ops::write(
-            (chunk_location.zone * self.chunks_per_zone) as u64 + chunk_location.addr,
+            get_address_at(
+                chunk_location.zone as u64,
+                chunk_location.addr,
+                (self.chunks_per_zone * self.chunk_size) as u64,
+                self.chunk_size as u64,
+            ),
             self.nvme_config.fd,
             0,
             self.nvme_config.nsid,
             self.nvme_config.logical_block_size,
-            mut_data.as_mut_slice()) {
-                Ok(()) => Ok(chunk_location),
-                Err(err) => Err(err.try_into().unwrap()),
+            mut_data.as_mut_slice(),
+        ) {
+            Ok(()) => Ok(chunk_location),
+            Err(err) => Err(err.try_into().unwrap()),
         }
     }
 
@@ -361,14 +386,26 @@ impl Device for BlockInterface {
     where
         Self: Sized,
     {
-        todo!()
+        let slba = get_address_at(
+            location.zone as u64,
+            location.addr,
+            (self.chunks_per_zone * self.chunk_size) as u64,
+            self.chunk_size as u64,
+        );
+
+        match nvme::ops::read(&self.nvme_config, slba, read_buffer) {
+            Ok(()) => Ok(()),
+            Err(err) => Err(err.try_into().unwrap()),
+        }
+    }
+
+    fn read(&self, location: ChunkLocation) -> std::io::Result<Vec<u8>> {
+        let mut buffer = vec![0; self.chunk_size];
+        self.read_into_buffer(location, &mut buffer);
+        Ok(buffer)
     }
 
     fn evict(&self, num_eviction: usize) -> std::io::Result<()> {
         Ok(())
-    }
-
-    fn read(&self, location: ChunkLocation) -> std::io::Result<Vec<u8>> {
-        Ok(Vec::new())
     }
 }

--- a/oxcache/src/device.rs
+++ b/oxcache/src/device.rs
@@ -1,6 +1,6 @@
-use nvme::info::is_zoned_device;
+use nvme::info::{is_zoned_device, nvme_get_info};
 use nvme::ops::{zns_append, zns_read};
-use nvme::types::ZNSConfig;
+use nvme::types::{NVMeConfig, ZNSConfig};
 use std::collections::VecDeque;
 use std::fs::OpenOptions;
 use std::io::Error;
@@ -48,9 +48,9 @@ impl ZoneList {
         }
 
         let mut zone = match self.available_zones.pop_front() {
-			Some(z) => z,
-			None => return Err(()),
-		};
+            Some(z) => z,
+            None => return Err(()),
+        };
         if zone.chunks_available > 1 {
             zone.chunks_available -= 1;
             self.available_zones.push_front(zone);
@@ -67,17 +67,20 @@ impl ZoneList {
         }
 
         let mut zone = match self.available_zones.pop_front() {
-			Some(z) => z,
-			None => return Err(()),
-		};
+            Some(z) => z,
+            None => return Err(()),
+        };
         let chunk_idx = self.chunks_per_zone - zone.chunks_available;
         if zone.chunks_available > 1 {
             zone.chunks_available -= 1;
             self.available_zones.push_front(zone);
         }
 
-        Ok(ChunkLocation { zone: zone.index, addr: chunk_idx as u64 })
-    }    
+        Ok(ChunkLocation {
+            zone: zone.index,
+            addr: chunk_idx as u64,
+        })
+    }
 
     // Check if all zones are full
     fn is_full(&self) -> bool {
@@ -103,11 +106,13 @@ impl ZoneList {
 }
 
 pub struct Zoned {
+    nvme_config: NVMeConfig,
     config: ZNSConfig,
     zones: Arc<Mutex<ZoneList>>,
     evict_policy: Arc<Mutex<dyn EvictionPolicy>>,
 }
 
+// Information about each zone
 #[derive(Clone)]
 pub struct BlockZoneInfo {
     write_pointer: u64,
@@ -116,7 +121,7 @@ pub struct BlockZoneInfo {
 pub struct BlockDeviceState {
     zones: Vec<BlockZoneInfo>,
     active_zones: ZoneList,
-    chunk_size: usize
+    chunk_size: usize,
 }
 
 impl BlockDeviceState {
@@ -131,31 +136,54 @@ impl BlockDeviceState {
 }
 
 pub struct BlockInterface {
-    fd: RawFd,
+    nvme_config: NVMeConfig,
+    chunk_size: usize,
+    chunks_per_zone: usize,
+    num_zones: usize,
     state: Arc<Mutex<BlockDeviceState>>,
-    evict_policy: Arc<Mutex<dyn EvictionPolicy>>
+    evict_policy: Arc<Mutex<dyn EvictionPolicy>>,
 }
 
 pub trait Device: Send + Sync {
     fn append(&self, data: Vec<u8>) -> std::io::Result<ChunkLocation>;
 
-    fn new(device: &str, chunk_size: usize, eviction_policy: Arc<Mutex<dyn EvictionPolicy>>) -> std::io::Result<Self>
+    fn new(
+        device: &str,
+        chunk_size: usize,
+        eviction_policy: Arc<Mutex<dyn EvictionPolicy>>,
+    ) -> std::io::Result<Self>
     where
         Self: Sized; // Args
 
-    fn read_into_buffer(&self, location: ChunkLocation, read_buffer: &mut [u8]) -> std::io::Result<()>;
+    fn read_into_buffer(
+        &self,
+        location: ChunkLocation,
+        read_buffer: &mut [u8],
+    ) -> std::io::Result<()>;
 
     fn evict(&self, num_eviction: usize) -> std::io::Result<()>;
-    
+
     fn read(&self, location: ChunkLocation) -> std::io::Result<Vec<u8>>;
 }
 
-pub fn get_device(device: &str, chunk_size: usize, eviction_policy: Arc<Mutex<dyn EvictionPolicy>>) -> std::io::Result<Arc<dyn Device>> {
+pub fn get_device(
+    device: &str,
+    chunk_size: usize,
+    eviction_policy: Arc<Mutex<dyn EvictionPolicy>>,
+) -> std::io::Result<Arc<dyn Device>> {
     let is_zoned = is_zoned_device(device)?;
     if is_zoned {
-        return Ok(Arc::new(device::Zoned::new(device, chunk_size, eviction_policy)?));
+        return Ok(Arc::new(device::Zoned::new(
+            device,
+            chunk_size,
+            eviction_policy,
+        )?));
     } else {
-        return Ok(Arc::new(device::BlockInterface::new(device, chunk_size, eviction_policy)?));
+        return Ok(Arc::new(device::BlockInterface::new(
+            device,
+            chunk_size,
+            eviction_policy,
+        )?));
     }
 }
 
@@ -175,17 +203,25 @@ impl Zoned {
 
 impl Device for Zoned {
     /// Hold internal state to keep track of zone state
-    fn new(device: &str, chunk_size: usize, eviction_policy: Arc<Mutex<dyn EvictionPolicy>>) -> std::io::Result<Self> {
-        match nvme::info::zns_get_info(device) {
+    fn new(
+        device: &str,
+        chunk_size: usize,
+        eviction_policy: Arc<Mutex<dyn EvictionPolicy>>,
+    ) -> std::io::Result<Self> {
+        let nvme_config = match nvme::info::nvme_get_info(device) {
+            Ok(config) => config,
+            Err(err) => return Err(err.try_into().unwrap()),
+        };
+
+        match nvme::info::zns_get_info(&nvme_config) {
             Ok(mut config) => {
                 config.chunks_per_zone = config.zone_size / chunk_size as u64;
                 config.chunk_size = chunk_size;
-                let zone_list = ZoneList::new(
-                    config.num_zones as usize,
-                    config.chunks_per_zone as usize,
-                );
+                let zone_list =
+                    ZoneList::new(config.num_zones as usize, config.chunks_per_zone as usize);
 
                 Ok(Self {
+                    nvme_config,
                     config,
                     zones: Arc::new(Mutex::new(zone_list)),
                     evict_policy: eviction_policy,
@@ -198,23 +234,33 @@ impl Device for Zoned {
     fn append(&self, data: Vec<u8>) -> std::io::Result<ChunkLocation> {
         let zone_index = self.get_free_zone()?;
         let mut mut_data = Vec::clone(&data);
-        match zns_append(&self.config, zone_index as u64, mut_data.as_mut_slice()) {
+        match zns_append(
+            &self.nvme_config,
+            &self.config,
+            zone_index as u64,
+            mut_data.as_mut_slice(),
+        ) {
             Ok(lba) => {
                 let mtx = Arc::clone(&self.evict_policy);
                 let policy = mtx.lock().unwrap();
                 policy.write_update(zone_index);
 
                 Ok(ChunkLocation::new(zone_index, lba))
-            },
+            }
             Err(err) => Err(err.try_into().unwrap()),
         }
     }
 
-    fn read_into_buffer(&self, location: ChunkLocation, read_buffer: &mut [u8]) -> std::io::Result<()>
+    fn read_into_buffer(
+        &self,
+        location: ChunkLocation,
+        read_buffer: &mut [u8],
+    ) -> std::io::Result<()>
     where
         Self: Sized,
     {
         match zns_read(
+            &self.nvme_config,
             &self.config,
             location.zone as u64,
             location.addr,
@@ -225,7 +271,7 @@ impl Device for Zoned {
                 let policy = mtx.lock().unwrap();
                 policy.read_update(location.zone);
                 Ok(())
-            },
+            }
             Err(err) => Err(err.try_into().unwrap()),
         }
     }
@@ -252,19 +298,6 @@ impl Device for Zoned {
 }
 
 impl BlockInterface {
-    fn get_free_zone(&self) -> std::io::Result<ChunkLocation> {
-        let mtx = Arc::clone(&self.state);
-        let mut state = mtx.lock().unwrap();
-        let zone_list = &mut state.active_zones;
-        match zone_list.remove_chunk_location() {
-            Ok(location) => Ok(location),
-            Err(()) => Err(std::io::Error::new(
-                std::io::ErrorKind::StorageFull,
-                "Cache is full",
-            )),
-        }
-    }
-    
     fn read(&self, location: ChunkLocation) -> std::io::Result<Vec<u8>> {
         Ok(Vec::new())
     }
@@ -272,34 +305,68 @@ impl BlockInterface {
 
 impl Device for BlockInterface {
     /// Hold internal state to keep track of "ssd" zone state
-    fn new(device: &str, chunk_size: usize, eviction_policy: Arc<Mutex<dyn EvictionPolicy>>) -> std::io::Result<Self> {
-        let handle = OpenOptions::new().read(true).write(true).open(device)?;
-        let fd = handle.as_raw_fd();
+    fn new(
+        device: &str,
+        chunk_size: usize,
+        eviction_policy: Arc<Mutex<dyn EvictionPolicy>>,
+    ) -> std::io::Result<Self> {
+        let nvme_config = match nvme::info::nvme_get_info(device) {
+            Ok(config) => config,
+            Err(err) => return Err(err.try_into().unwrap()),
+        };
 
         // Num_zones: how to get?
         let num_zones = 100;
         // Chunks per zone: how to get?
         let chunks_per_zone = 100;
 
-        Ok(Self { fd, state: Arc::new(Mutex::new(BlockDeviceState::new(num_zones, chunks_per_zone, chunk_size))), evict_policy: eviction_policy })
+        Ok(Self {
+            nvme_config,
+            state: Arc::new(Mutex::new(BlockDeviceState::new(
+                num_zones,
+                chunks_per_zone,
+                chunk_size,
+            ))),
+            evict_policy: eviction_policy,
+            chunk_size,
+            chunks_per_zone,
+            num_zones,
+        })
     }
 
     fn append(&self, data: Vec<u8>) -> std::io::Result<ChunkLocation> {
         let mtx = self.state.clone();
-        let state = mtx.lock().unwrap();
-        let chunk_location = self.get_free_zone()?;
-        
+        let mut state = mtx.lock().unwrap();
+        let chunk_location = match state.active_zones.remove_chunk_location() {
+            Ok(location) => location,
+            Err(()) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::StorageFull,
+                    "Cache is full",
+                ));
+            }
+        };
+        drop(state);
+
         let mut mut_data = Vec::clone(&data);
 
-        // match nvme::ops::write(chunk_location.zone * , mut_data.as_mut_slice()) {
-            // Ok(_) => todo!(),
-            // Err(_) => todo!(),
-        // }
-
-        Ok(ChunkLocation::new(0, 0))
+        match nvme::ops::write(
+            (chunk_location.zone * self.chunks_per_zone) as u64 + chunk_location.addr,
+            self.nvme_config.fd,
+            0,
+            self.nvme_config.nsid,
+            self.nvme_config.logical_block_size,
+            mut_data.as_mut_slice()) {
+                Ok(()) => Ok(chunk_location),
+                Err(err) => Err(err.try_into().unwrap()),
+        }
     }
 
-    fn read_into_buffer(&self, location: ChunkLocation, read_buffer: &mut [u8]) -> std::io::Result<()> 
+    fn read_into_buffer(
+        &self,
+        location: ChunkLocation,
+        read_buffer: &mut [u8],
+    ) -> std::io::Result<()>
     where
         Self: Sized,
     {

--- a/rsync_and_compile.sh
+++ b/rsync_and_compile.sh
@@ -1,0 +1,14 @@
+rsync -avP \
+      Cargo.lock \
+      Cargo.toml \
+      example.server.toml \
+      'libnvme-sys' \
+      'nvme' \
+      'oxcache' \
+      ubuntu@127.0.0.1:/home/ubuntu/OxCacheLocal/
+
+sshpass -p "ubuntu" ssh -o StrictHostKeyChecking=no -p 2222 ubuntu@127.0.0.1 << 'EOF'
+cd /home/ubuntu/OxCacheLocal/
+cargo build
+EOF
+


### PR DESCRIPTION
This PR separates ZNSConfig into NVMeConfig, which stores things that are common between block and zns interface drives. ZNSConfig is changed to store only ZNS interface specific data. 

Additionally implement read and append for the block interface drive.

There's a lot of noise here because I ran cargo fmt.