### PR TITLE
Add promotional eviction

### DIFF
--- a/example.server.toml
+++ b/example.server.toml
@@ -10,7 +10,6 @@ remote_type = "emulated" # emulated | S3
 bucket = "S3_BUCKET"
 
 [eviction]
-eviction_policy = "dummy"
-num_evict = 1
-high_water_evict = 3
-low_water_evict = 1
+eviction_policy = "promotional"
+high_water_evict = 1 # Number remaining from end
+low_water_evict = 3

--- a/oxcache/src/cache/bucket.rs
+++ b/oxcache/src/cache/bucket.rs
@@ -15,12 +15,12 @@ pub struct Chunk {
 #[derive(Clone)]
 pub struct ChunkLocation {
     pub zone: usize,
-    pub addr: u64, // The chunk index
+    pub index: u64, // The chunk index
 }
 
 impl ChunkLocation {
     pub fn new(zone: usize, addr: u64) -> Self {
-        Self { zone, addr }
+        Self { zone, index: addr }
     }
 }
 

--- a/oxcache/src/device.rs
+++ b/oxcache/src/device.rs
@@ -79,7 +79,7 @@ impl ZoneList {
 
         Ok(ChunkLocation {
             zone: zone.index,
-            addr: chunk_idx as u64,
+            index: chunk_idx as u64,
         })
     }
 
@@ -276,13 +276,13 @@ impl Device for Zoned {
             &self.nvme_config,
             &self.config,
             location.zone as u64,
-            location.addr,
+            location.index,
             read_buffer,
         ) {
             Ok(()) => {
                 let mtx = Arc::clone(&self.evict_policy);
                 let mut policy = mtx.lock().unwrap();
-                policy.read_update(ChunkLocation::new(location.zone, location.addr));
+                policy.read_update(ChunkLocation::new(location.zone, location.index));
                 Ok(())
             }
             Err(err) => Err(err.try_into().unwrap()),
@@ -380,7 +380,7 @@ impl Device for BlockInterface {
         match nvme::ops::write(
             get_address_at(
                 chunk_location.zone as u64,
-                chunk_location.addr,
+                chunk_location.index,
                 (self.chunks_per_zone * self.chunk_size) as u64,
                 self.chunk_size as u64,
             ),
@@ -394,7 +394,7 @@ impl Device for BlockInterface {
                 let mtx = Arc::clone(&self.evict_policy);
                 let mut policy = mtx.lock().unwrap();
                 policy.write_update(ChunkLocation::new(
-                    chunk_location.zone, chunk_location.addr, // addr should be in chunks
+                    chunk_location.zone, chunk_location.index, // addr should be in chunks
                 ));
                 Ok(chunk_location)
             },
@@ -412,7 +412,7 @@ impl Device for BlockInterface {
     {
         let slba = get_address_at(
             location.zone as u64,
-            location.addr,
+            location.index,
             (self.chunks_per_zone * self.chunk_size) as u64,
             self.chunk_size as u64,
         );

--- a/oxcache/src/device.rs
+++ b/oxcache/src/device.rs
@@ -303,14 +303,11 @@ impl Device for Zoned {
             EvictionPolicyWrapper::Chunk(p) => {
                 unimplemented!()
             }
-            EvictionPolicyWrapper::Promotional(p) => match p.get_evict_targets() {
-                Some(evict_targets) => {
-                    let zone_mtx = Arc::clone(&self.zones);
-                    let mut zones = zone_mtx.lock().unwrap();
-                    zones.reset_zones(evict_targets);
-                    Ok(())
-                }
-                None => Ok(()) // Nothing to evict,
+            EvictionPolicyWrapper::Promotional(p) => {
+                let zone_mtx = Arc::clone(&self.zones);
+                let mut zones = zone_mtx.lock().unwrap();
+                zones.reset_zones(p.get_evict_targets());
+                Ok(())
             },
         }
     }
@@ -437,14 +434,11 @@ impl Device for BlockInterface {
             EvictionPolicyWrapper::Chunk(p) => {
                 unimplemented!()
             }
-            EvictionPolicyWrapper::Promotional(p) => match p.get_evict_targets() {
-                Some(evict_targets) => {
-                    let state_mtx = Arc::clone(&self.state);
-                    let mut state = state_mtx.lock().unwrap();
-                    state.active_zones.reset_zones(evict_targets);
-                    Ok(())
-                }
-                None => Ok(()) // Nothing to evict,
+            EvictionPolicyWrapper::Promotional(p) => {
+                let state_mtx = Arc::clone(&self.state);
+                let mut state = state_mtx.lock().unwrap();
+                state.active_zones.reset_zones(p.get_evict_targets());
+                Ok(())
             },
         }
     }

--- a/oxcache/src/device.rs
+++ b/oxcache/src/device.rs
@@ -162,7 +162,7 @@ pub trait Device: Send + Sync {
         read_buffer: &mut [u8],
     ) -> std::io::Result<()>;
 
-    fn evict(&self, num_eviction: usize) -> std::io::Result<()>;
+    fn evict(&self) -> std::io::Result<()>;
 
     fn read(&self, location: ChunkLocation) -> std::io::Result<Vec<u8>>;
 }
@@ -295,7 +295,7 @@ impl Device for Zoned {
         Ok(data)
     }
 
-    fn evict(&self, num_eviction: usize) -> std::io::Result<()> {
+    fn evict(&self) -> std::io::Result<()> {
         let mtx = Arc::clone(&self.evict_policy);
         let mut policy = mtx.lock().unwrap();
         match &mut *policy {
@@ -310,7 +310,7 @@ impl Device for Zoned {
                     zones.reset_zones(evict_targets);
                     Ok(())
                 }
-                None => Err(Error::new(std::io::ErrorKind::Other, "No items to evict")),
+                None => Ok(()) // Nothing to evict,
             },
         }
     }
@@ -429,7 +429,7 @@ impl Device for BlockInterface {
         Ok(buffer)
     }
 
-    fn evict(&self, num_eviction: usize) -> std::io::Result<()> {
+    fn evict(&self) -> std::io::Result<()> {
         let mtx = Arc::clone(&self.evict_policy);
         let mut policy = mtx.lock().unwrap();
         match &mut *policy {
@@ -444,7 +444,7 @@ impl Device for BlockInterface {
                     state.active_zones.reset_zones(evict_targets);
                     Ok(())
                 }
-                None => Err(Error::new(std::io::ErrorKind::Other, "No items to evict")),
+                None => Ok(()) // Nothing to evict,
             },
         }
     }

--- a/oxcache/src/eviction.rs
+++ b/oxcache/src/eviction.rs
@@ -195,7 +195,7 @@ impl Evictor {
                     // TODO: Put eviction logic here
                     println!("Evictor running...");
 
-                    device.evict(1).expect("Eviction failed");
+                    device.evict().expect("Eviction failed");
 
                     // Sleep to simulate periodic work
                     thread::sleep(Duration::from_secs(5));

--- a/oxcache/src/eviction.rs
+++ b/oxcache/src/eviction.rs
@@ -108,7 +108,7 @@ impl EvictionPolicy for PromotionalEvictionPolicy {
     fn write_update(&mut self, chunk: ChunkLocation) {
         assert!(!self.lru.contains(&chunk.zone));
         // We only want to put it in the LRU once the zone is full
-        if (chunk.addr as usize == self.nr_chunks_per_zone-1) {
+        if (chunk.index as usize == self.nr_chunks_per_zone-1) {
             self.lru.put(chunk.zone, ());
         }
     }

--- a/oxcache/src/eviction.rs
+++ b/oxcache/src/eviction.rs
@@ -19,23 +19,23 @@ pub enum EvictionPolicyWrapper {
 }
 
 impl EvictionPolicyWrapper {
-    pub fn new(identifier: &str, num_evict: usize, high_water: usize, low_water: usize, nr_zones: usize, nr_chunks_per_zone: usize) -> tokio::io::Result<Self> {
+    pub fn new(identifier: &str, high_water: usize, low_water: usize, nr_zones: usize, nr_chunks_per_zone: usize) -> tokio::io::Result<Self> {
         match identifier.to_lowercase().as_str() {
-            "dummy" => Ok(EvictionPolicyWrapper::Dummy(DummyEvictionPolicy::new(num_evict, high_water, low_water, nr_zones, nr_chunks_per_zone))),
-            "chunk" => Ok(EvictionPolicyWrapper::Chunk(ChunkEvictionPolicy::new(num_evict, high_water, low_water, nr_zones, nr_chunks_per_zone))),
-            "promotional" => Ok(EvictionPolicyWrapper::Promotional(PromotionalEvictionPolicy::new(num_evict, high_water, low_water, nr_zones, nr_chunks_per_zone))),
+            "dummy" => Ok(EvictionPolicyWrapper::Dummy(DummyEvictionPolicy::new(high_water, low_water, nr_zones, nr_chunks_per_zone))),
+            "chunk" => Ok(EvictionPolicyWrapper::Chunk(ChunkEvictionPolicy::new(high_water, low_water, nr_zones, nr_chunks_per_zone))),
+            "promotional" => Ok(EvictionPolicyWrapper::Promotional(PromotionalEvictionPolicy::new(high_water, low_water, nr_zones, nr_chunks_per_zone))),
             _ => Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, identifier)),
         }
     }
     
-    pub fn write_update(&self, chunk: ChunkLocation) {
+    pub fn write_update(&mut self, chunk: ChunkLocation) {
         match self { 
             EvictionPolicyWrapper::Dummy(dummy) => dummy.write_update(chunk),
             EvictionPolicyWrapper::Promotional(promotional) => promotional.write_update(chunk),
             EvictionPolicyWrapper::Chunk(c) => c.write_update(chunk),
         }
     }    
-    pub fn read_update(&self, chunk: ChunkLocation) {
+    pub fn read_update(&mut self, chunk: ChunkLocation) {
         match self {
             EvictionPolicyWrapper::Dummy(dummy) => dummy.read_update(chunk),
             EvictionPolicyWrapper::Promotional(promotional) => promotional.read_update(chunk),
@@ -47,14 +47,13 @@ impl EvictionPolicyWrapper {
 pub trait EvictionPolicy: Send + Sync {
     type Target: Clone + Send + Sync + 'static;
 
-    fn write_update(&self, chunk: ChunkLocation);
-    fn read_update(&self, chunk: ChunkLocation);
-    fn get_evict_targets(&self) -> Option<Vec<Self::Target>>;
-    fn get_evict_target(&self) -> Option<Self::Target>;
+    fn write_update(&mut self, chunk: ChunkLocation);
+    fn read_update(&mut self, chunk: ChunkLocation);
+    fn get_evict_targets(&mut self) -> Option<Vec<Self::Target>>;
+    fn get_evict_target(&mut self) -> Option<Self::Target>;
 }
 
 pub struct DummyEvictionPolicy {
-    num_evict: usize,
     high_water: usize,
     low_water: usize,
     nr_zones: usize,
@@ -62,30 +61,29 @@ pub struct DummyEvictionPolicy {
 }
 
 impl DummyEvictionPolicy {
-    pub fn new(num_evict: usize, high_water: usize, low_water: usize, nr_zones: usize, nr_chunks_per_zone: usize) -> Self {
+    pub fn new(high_water: usize, low_water: usize, nr_zones: usize, nr_chunks_per_zone: usize) -> Self {
         Self {
-            num_evict, high_water, low_water, nr_zones, nr_chunks_per_zone
+            high_water, low_water, nr_zones, nr_chunks_per_zone
         }
     }
 }
 
 impl EvictionPolicy for DummyEvictionPolicy {
     type Target = usize;
-    fn write_update(&self, chunk: ChunkLocation) {}
+    fn write_update(&mut self, chunk: ChunkLocation) {}
 
-    fn read_update(&self, chunk: ChunkLocation) {}
+    fn read_update(&mut self, chunk: ChunkLocation) {}
 
-    fn get_evict_targets(&self) -> Option<Vec<Self::Target>> {
+    fn get_evict_targets(&mut self) -> Option<Vec<Self::Target>> {
         unimplemented!();
     }
 
-    fn get_evict_target(&self) -> Option<Self::Target> {
+    fn get_evict_target(&mut self) -> Option<Self::Target> {
         unimplemented!();
     }
 }
 
 pub struct PromotionalEvictionPolicy {
-    num_evict: usize,
     high_water: usize,
     low_water: usize,
     nr_zones: usize,
@@ -94,10 +92,10 @@ pub struct PromotionalEvictionPolicy {
 }
 
 impl PromotionalEvictionPolicy {
-    pub fn new(num_evict: usize, high_water: usize, low_water: usize, nr_zones: usize, nr_chunks_per_zone: usize) -> Self {
-        let lru = LruCache::new(NonZeroUsize::new(nr_zones).unwrap());
+    pub fn new(high_water: usize, low_water: usize, nr_zones: usize, nr_chunks_per_zone: usize) -> Self {
+        let lru = LruCache::unbounded();
         Self {
-            num_evict, high_water, low_water, nr_zones, nr_chunks_per_zone, lru
+            high_water, low_water, nr_zones, nr_chunks_per_zone, lru
         }
     }
 }
@@ -107,25 +105,44 @@ impl EvictionPolicy for PromotionalEvictionPolicy {
     /// Performs LRU based on full zones
     type Target = usize;
     
-    fn write_update(&self, chunk: ChunkLocation) {
-        // in pq, map zone id to
+    fn write_update(&mut self, chunk: ChunkLocation) {
+        assert!(!self.lru.contains(&chunk.zone));
+        // We only want to put it in the LRU once the zone is full
+        if (chunk.addr as usize == self.nr_chunks_per_zone-1) {
+            self.lru.put(chunk.zone, ());
+        }
     }
 
-    fn read_update(&self, chunk: ChunkLocation) {
-        unimplemented!();
+    fn read_update(&mut self, chunk: ChunkLocation) {
+        // We only want to put it in the LRU once the zone is full
+        // If it has filled before we want to update every time "promoting" it
+        // Following this, only zones that have filled prior are updated
+        if self.lru.contains(&chunk.zone) {
+            self.lru.put(chunk.zone, ());
+        }
     }
 
-    fn get_evict_targets(&self) -> Option<Vec<Self::Target>> {
-        unimplemented!();
+    fn get_evict_targets(&mut self) -> Option<Vec<Self::Target>> {
+        let high_water_mark =  self.nr_zones-self.high_water;
+        if self.lru.len() < high_water_mark {
+            return None;
+        }
+
+        let mut targets = Vec::with_capacity(self.lru.len() - self.low_water);
+        let low_water_mark = self.nr_zones-self.low_water;
+        while self.lru.len() > low_water_mark {
+            targets.push(self.lru.pop_lru().unwrap().0)
+        }
+
+        Some(targets)
     }
 
-    fn get_evict_target(&self) -> Option<Self::Target> {
-        unimplemented!();
+    fn get_evict_target(&mut self) -> Option<Self::Target> {
+        Some(0)
     }
 }
 
 pub struct ChunkEvictionPolicy {
-    num_evict: usize,
     high_water: usize,
     low_water: usize,
     nr_zones: usize,
@@ -133,28 +150,28 @@ pub struct ChunkEvictionPolicy {
 }
 
 impl ChunkEvictionPolicy {
-    pub fn new(num_evict: usize, high_water: usize, low_water: usize, nr_zones: usize, nr_chunks_per_zone: usize) -> Self {
+    pub fn new(high_water: usize, low_water: usize, nr_zones: usize, nr_chunks_per_zone: usize) -> Self {
         Self {
-            num_evict, high_water, low_water, nr_zones, nr_chunks_per_zone
+            high_water, low_water, nr_zones, nr_chunks_per_zone
         }
     }
 }
 
 impl EvictionPolicy for ChunkEvictionPolicy {
     type Target = ChunkLocation;
-    fn write_update(&self, chunk: ChunkLocation) {
+    fn write_update(&mut self, chunk: ChunkLocation) {
         unimplemented!();
     }
 
-    fn read_update(&self, chunk: ChunkLocation) {
+    fn read_update(&mut self, chunk: ChunkLocation) {
         unimplemented!();
     }
 
-    fn get_evict_targets(&self) -> Option<Vec<Self::Target>> {
+    fn get_evict_targets(&mut self) -> Option<Vec<Self::Target>> {
         unimplemented!();
     }
 
-    fn get_evict_target(&self) -> Option<Self::Target> {
+    fn get_evict_target(&mut self) -> Option<Self::Target> {
         unimplemented!();
     }
 }
@@ -212,5 +229,70 @@ impl Evictor {
         } else {
             eprintln!("Evictor thread was already stopped or never started.");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    fn compare_order(policy: &mut PromotionalEvictionPolicy, order: Vec<usize>) {
+        assert_eq!(order.len(), policy.lru.len(), "Expected len = {}, but got len = {}", order.len(), policy.lru.len());
+        for (index, ((lru_key, _), order_item)) in policy.lru.iter().zip(order.iter()).enumerate() {
+            assert_eq!(order_item, lru_key, "Expected {}, but got {}", order_item,lru_key);
+        }
+    }
+
+    #[test]
+    fn test_promotional_write_update_ordering() {
+        let mut policy = PromotionalEvictionPolicy {
+            high_water: 1,
+            low_water: 3,
+            nr_zones: 4,
+            nr_chunks_per_zone: 2,
+            lru: LruCache::new(NonZeroUsize::new(10).unwrap()),
+        };
+
+        // zone=[_,_,_,_], lru=()
+        let order: Vec<usize> = vec![];
+        policy.write_update(ChunkLocation::new(3, 0));
+        compare_order(&mut policy, vec![]);
+        let et = policy.get_evict_targets();
+        let expect_none: Option<Vec<usize>> = None;
+        assert_eq!(expect_none, et, "Expected = {:?}, but got {:?}", expect_none, et);
+        
+        // zone=[_,_,_,_], lru=()
+        policy.write_update(ChunkLocation::new(3, 1));
+        // zone=[_,_,_,3], lru=(3)
+        compare_order(&mut policy, vec![3]);
+        let et = policy.get_evict_targets();
+        assert_eq!(expect_none, et, "Expected = {:?}, but got {:?}", expect_none, et);
+        
+        policy.write_update(ChunkLocation::new(1, 0));
+        // There should be no change
+        // zone=[_,_,_,3], lru=(3)
+        compare_order(&mut policy, vec![3]);
+        
+        policy.write_update(ChunkLocation::new(1, 1));
+        // zone=[_,1,_,3], lru=(3, 1)
+        compare_order(&mut policy, vec![1, 3]);
+        let et = policy.get_evict_targets();
+        assert_eq!(expect_none, et, "Expected = {:?}, but got {:?}", expect_none, et);
+        
+        policy.write_update(ChunkLocation::new(2, 0));
+        policy.write_update(ChunkLocation::new(2, 1));
+        // zone=[_,1,2,3], lru=(3, 1, 2)
+        compare_order(&mut policy, vec![2, 1, 3]);
+
+        // Should update in place, and adjust order
+        policy.read_update(ChunkLocation::new(1, 1));
+        // zone=[_,1,2,3], lru=(3, 2, 1)
+        compare_order(&mut policy, vec![1, 2, 3]);
+
+        let et = policy.get_evict_targets();
+        let expect = Some(vec![3, 2]);
+        assert_eq!(expect, et, "Expected = {:?}, but got {:?}", expect, et);
+
+        compare_order(&mut policy, vec![1]);
     }
 }

--- a/oxcache/src/main.rs
+++ b/oxcache/src/main.rs
@@ -39,9 +39,6 @@ pub struct CliArgs {
     pub eviction_policy: Option<String>,
     
     #[arg(long)]
-    pub num_evict: Option<usize>,
-    
-    #[arg(long)]
     pub high_water_evict: Option<usize>,
     
     #[arg(long)]
@@ -66,7 +63,6 @@ pub struct ParsedRemoteConfig {
 #[derive(Debug, Deserialize)]
 pub struct ParsedEvictionConfig {
     pub eviction_policy: Option<String>,
-    pub num_evict: Option<usize>,
     pub high_water_evict: Option<usize>,
     pub low_water_evict: Option<usize>,
 }
@@ -144,11 +140,6 @@ fn load_config(cli: &CliArgs) -> Result<ServerConfig, Box<dyn std::error::Error>
         .or_else(|| config.as_ref()?.eviction.eviction_policy.clone())
         .ok_or("Missing eviction policy")?
         .to_lowercase();
-    let num_evict = cli
-        .num_evict
-        .clone()
-        .or_else(|| config.as_ref()?.eviction.num_evict.clone())
-        .ok_or("Missing num_evict")?;
     let high_water_evict = cli
         .high_water_evict
         .clone()
@@ -164,9 +155,6 @@ fn load_config(cli: &CliArgs) -> Result<ServerConfig, Box<dyn std::error::Error>
         return Err("low_water_evict must be greater than high_water_evict".into());
     }
     
-    if num_evict == 0 {
-        return Err("num_evict must be greater than 0".into());
-    }
         
     let chunk_size = cli
         .chunk_size

--- a/oxcache/src/main.rs
+++ b/oxcache/src/main.rs
@@ -160,8 +160,8 @@ fn load_config(cli: &CliArgs) -> Result<ServerConfig, Box<dyn std::error::Error>
         .or_else(|| config.as_ref()?.eviction.low_water_evict.clone())
         .ok_or("Missing low_water_evict")?;
     
-    if low_water_evict > high_water_evict {
-        return Err("low_water_evict must be less than high_water_evict".into());
+    if low_water_evict < high_water_evict {
+        return Err("low_water_evict must be greater than high_water_evict".into());
     }
     
     if num_evict == 0 {
@@ -187,7 +187,6 @@ fn load_config(cli: &CliArgs) -> Result<ServerConfig, Box<dyn std::error::Error>
         },
         eviction: ServerEvictionConfig {
             eviction_type: eviction_policy,
-            num_evict,
             high_water_evict,
             low_water_evict,
         },        

--- a/oxcache/src/server.rs
+++ b/oxcache/src/server.rs
@@ -29,7 +29,6 @@ pub struct ServerRemoteConfig {
 #[derive(Debug, Clone)]
 pub struct ServerEvictionConfig {
     pub eviction_type: String,
-    pub num_evict: usize,
     pub high_water_evict: usize,
     pub low_water_evict: usize,
 }


### PR DESCRIPTION
The eviction algorithm updates an internal lru when a write is made to the last chunk 

When a read is done, if the chunk is already present in the lru, it is promoted. 

When targets are requested, they are popped off the lru and returned to the caller.

Associated tests check the above is working correctly