### PR TITLE
Implement removing items from cache

### DIFF
--- a/oxcache/src/cache/mod.rs
+++ b/oxcache/src/cache/mod.rs
@@ -21,7 +21,7 @@ impl Cache {
     pub fn new(num_zones: usize) -> Self {
         Self {
             buckets: RwLock::new(HashMap::new()),
-            zone_to_entry: Mutex::new(vec![Vec::new(); num_zones])
+            zone_to_entry: Mutex::new(vec![Vec::with_capacity(chunks_per_zone); num_zones])
         }
     }
     

--- a/oxcache/src/cache/mod.rs
+++ b/oxcache/src/cache/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::sync::Arc;
+use futures::lock::Mutex;
 use tokio::sync::{Notify, RwLock};
 use crate::cache::bucket::{ChunkLocation, Chunk, ChunkState};
 use crate::readerpool::ReaderPool;
@@ -13,12 +14,14 @@ pub mod bucket;
 #[derive(Debug)]
 pub struct Cache {
     buckets: RwLock<HashMap<Chunk, Arc<RwLock<ChunkState>>>>,
+    zone_to_entry: Mutex<Vec<Vec<Chunk>>>
 }
 
 impl Cache {
-    pub fn new() -> Self {
+    pub fn new(num_zones: usize) -> Self {
         Self {
             buckets: RwLock::new(HashMap::new()),
+            zone_to_entry: Mutex::new(vec![Vec::new(); num_zones])
         }
     }
     
@@ -114,13 +117,318 @@ impl Cache {
                         return Err(e);
                     },
                     Ok(location) => {
+                        let zone = location.zone;
                         *chunk_loc_guard = ChunkState::Ready(Arc::new(location));
+                        let mut reverse_mapping_guard = self.zone_to_entry.lock().await;
+                        reverse_mapping_guard[zone].push(key);
                     }
                 }
                 return Ok(())
             }
         }
     }   
+
+    pub async fn remove_zone(&self, zone_index: usize) -> tokio::io::Result<()> {
+        let mut map_guard = self.buckets.write().await;
+        let mut guard = self.zone_to_entry.lock().await;
+
+        for chunk in &guard[zone_index] {
+            map_guard.remove(chunk);
+        }
+
+        guard.clear();
+
+        Ok(())
+    }
+
 }
 
+#[cfg(test)]
+mod map_tests {
+    use std::sync::Arc;
 
+    use crate::cache::{bucket::{Chunk, ChunkLocation}, Cache};
+
+    #[tokio::test]
+    async fn test_insert() {
+        let cache = Cache::new(10);
+        match cache.get_or_insert_with(Chunk::new(String::from("fake-uuid"), 120, 10),
+            |_| async move {
+                assert!(false, "Shouldn't reach here");
+                Ok(())
+            },
+            || async move {
+                Ok(ChunkLocation::new(0, 20))
+            }
+        ).await {
+            Ok(()) => (),
+            Err(err) => assert!(false, "Error occurred: {err}"),
+        }
+
+        match cache.get_or_insert_with(Chunk::new(String::from("fake-uuid"), 120, 10),
+            |loc| async move {
+                assert!(loc.zone == 0);
+                assert!(loc.index == 20);
+                Ok(())
+            },
+            || async move {
+                assert!(false, "Shouldn't reach here");
+                Ok(ChunkLocation::new(0, 0))
+            }
+        ).await {
+            Ok(()) => (),
+            Err(err) => assert!(false, "Error occurred: {err}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_insert_similar() {
+        let cache = Cache::new(10);
+
+        let fail_path = async |_: Arc<ChunkLocation>| {
+            assert!(false, "Shouldn't reach here");
+            Ok(())
+        };
+
+        let fail_write_path = async || -> tokio::io::Result<ChunkLocation> {
+            assert!(false, "Shouldn't reach here");
+            Ok(ChunkLocation { zone: 0, index: 0 })
+        };
+
+        let check_err = |result| {
+            match result {
+                Ok(()) => (),
+                Err(err) => assert!(false, "Error occurred: {err}"),
+            }
+        };
+
+        // Insert multiple similar entries
+        let entry1 = Chunk::new(String::from("fake-uuid"), 120, 10);
+        let entry2 = Chunk::new(String::from("fake-uuid!"), 120, 10);
+        let entry3 = Chunk::new(String::from("fake-uuid"), 121, 10);
+        let entry4 = Chunk::new(String::from("fake-uuid"), 121, 11);
+
+        let chunk_loc1 = ChunkLocation::new(0, 20);
+        let chunk_loc2 = ChunkLocation::new(1, 22);
+        let chunk_loc3 = ChunkLocation::new(9, 25);
+        let chunk_loc4 = ChunkLocation::new(7, 29);
+
+        check_err(cache.get_or_insert_with(entry1.clone(),
+            fail_path,
+            {
+                let chunk_loc1 = chunk_loc1.clone();
+                || async { Ok(chunk_loc1) }
+            }).await);
+
+        check_err(cache.get_or_insert_with(entry2.clone(),
+            fail_path,
+            {
+                let chunk_loc2 = chunk_loc2.clone();
+                || async { Ok(chunk_loc2) }
+            }).await);
+
+        check_err(cache.get_or_insert_with(entry3.clone(),
+            fail_path,
+            {
+                let chunk_loc3 = chunk_loc3.clone();
+                || async { Ok(chunk_loc3) }
+            }).await);
+
+        check_err(cache.get_or_insert_with(entry4.clone(),
+            fail_path,
+            {
+                let chunk_loc4 = chunk_loc4.clone();
+                || async { Ok(chunk_loc4) }
+            }).await);
+
+        check_err(cache.get_or_insert_with(entry1,
+            {
+                |cl| async move {
+                    let cl = Arc::clone(&cl);
+                    assert_eq!(*cl, chunk_loc1);
+                    Ok(())
+                }
+            },
+            fail_write_path
+        ).await);
+
+        check_err(cache.get_or_insert_with(entry2,
+            {
+                |cl| async move {
+                    let cl = Arc::clone(&cl);
+                    assert_eq!(*cl, chunk_loc2);
+                    Ok(())
+                }
+            },
+            fail_write_path
+        ).await);
+
+        check_err(cache.get_or_insert_with(entry3,
+            {
+                |cl| async move {
+                    let cl = Arc::clone(&cl);
+                    assert_eq!(*cl, chunk_loc3);
+                    Ok(())
+                }
+            },
+            fail_write_path
+        ).await);
+
+        check_err(cache.get_or_insert_with(entry4,
+            {
+                |cl| async move {
+                    let cl = Arc::clone(&cl);
+                    assert_eq!(*cl, chunk_loc4);
+                    Ok(())
+                }
+            },
+            fail_write_path
+        ).await);
+    }
+
+    #[tokio::test]
+    async fn test_remove() {
+        let cache = Cache::new(10);
+
+        let fail_path = async |_: Arc<ChunkLocation>| {
+            assert!(false, "Shouldn't reach here");
+            Ok(())
+        };
+
+        let fail_write_path = async || -> tokio::io::Result<ChunkLocation> {
+            assert!(false, "Shouldn't reach here");
+            Ok(ChunkLocation { zone: 0, index: 0 })
+        };
+
+        let check_err = |result| {
+            match result {
+                Ok(()) => (),
+                Err(err) => assert!(false, "Error occurred: {err}"),
+            }
+        };
+
+        let entry = Chunk::new(String::from("fake-uuid"), 120, 10);
+        let chunk_loc = ChunkLocation::new(0, 20);
+
+        // Insert
+        check_err(cache.get_or_insert_with(entry.clone(),
+            fail_path,
+            {
+                let chunk_loc = chunk_loc.clone();
+                || async { Ok(chunk_loc) }
+            }).await);
+
+        // Check insertion
+        check_err(cache.get_or_insert_with(entry.clone(),
+            {
+                let chunk_loc = chunk_loc.clone();
+                |cl| async move {
+                    let cl = Arc::clone(&cl);
+                    assert_eq!(*cl, chunk_loc);
+                    Ok(())
+                }
+            },
+            fail_write_path
+        ).await);
+
+        // Remove
+        check_err(cache.remove_zone(0).await);
+
+        // Check insertion is removed
+        check_err(cache.get_or_insert_with(entry.clone(),
+            fail_path,
+            {
+                let chunk_loc = chunk_loc.clone();
+                || async { Ok(chunk_loc) }
+            }).await);
+
+    }
+
+#[tokio::test]
+    async fn test_multiple_remove() {
+        let cache = Cache::new(10);
+
+        let fail_path = async |_: Arc<ChunkLocation>| {
+            assert!(false, "Shouldn't reach here");
+            Ok(())
+        };
+
+        let fail_write_path = async || -> tokio::io::Result<ChunkLocation> {
+            assert!(false, "Shouldn't reach here");
+            Ok(ChunkLocation { zone: 0, index: 0 })
+        };
+
+        let check_err = |result| {
+            match result {
+                Ok(()) => (),
+                Err(err) => assert!(false, "Error occurred: {err}"),
+            }
+        };
+
+        let entry = Chunk::new(String::from("fake-uuid"), 120, 10);
+        let chunk_loc = ChunkLocation::new(0, 20);
+
+        let entry2 = Chunk::new(String::from("fake-uuid"), 120, 10);
+        let chunk_loc2 = ChunkLocation::new(0, 21);
+
+        // Insert
+        check_err(cache.get_or_insert_with(entry.clone(),
+            fail_path,
+            {
+                let chunk_loc = chunk_loc.clone();
+                || async { Ok(chunk_loc) }
+            }).await);
+
+        check_err(cache.get_or_insert_with(entry2.clone(),
+            fail_path,
+            {
+                let chunk_loc = chunk_loc2.clone();
+                || async { Ok(chunk_loc) }
+            }).await);
+
+        // Check insertion
+        check_err(cache.get_or_insert_with(entry.clone(),
+            {
+                let chunk_loc = chunk_loc.clone();
+                |cl| async move {
+                    let cl = Arc::clone(&cl);
+                    assert_eq!(*cl, chunk_loc);
+                    Ok(())
+                }
+            },
+            fail_write_path
+        ).await);
+
+        check_err(cache.get_or_insert_with(entry2.clone(),
+            {
+                let chunk_loc = chunk_loc2.clone();
+                |cl| async move {
+                    let cl = Arc::clone(&cl);
+                    assert_eq!(*cl, chunk_loc);
+                    Ok(())
+                }
+            },
+            fail_write_path
+        ).await);
+
+        // Remove
+        check_err(cache.remove_zone(0).await);
+
+        // Check insertion is removed
+        check_err(cache.get_or_insert_with(entry.clone(),
+            fail_path,
+            {
+                let chunk_loc = chunk_loc.clone();
+                || async { Ok(chunk_loc) }
+            }).await);
+
+        check_err(cache.get_or_insert_with(entry2.clone(),
+            fail_path,
+            {
+                let chunk_loc = chunk_loc2.clone();
+                || async { Ok(chunk_loc) }
+            }).await);
+
+    }
+
+}

--- a/oxcache/src/device.rs
+++ b/oxcache/src/device.rs
@@ -165,6 +165,8 @@ pub trait Device: Send + Sync {
     fn evict(&self) -> std::io::Result<()>;
 
     fn read(&self, location: ChunkLocation) -> std::io::Result<Vec<u8>>;
+
+    fn get_num_zones(&self) -> usize;
 }
 
 fn get_aligned_buffer_size(buffer_size: usize, block_size: usize) -> usize {
@@ -324,6 +326,10 @@ impl Device for Zoned {
             },
         }
     }
+
+    fn get_num_zones(&self) -> usize {
+        self.config.num_zones as usize
+    }
 }
 
 impl BlockInterface {
@@ -455,5 +461,9 @@ impl Device for BlockInterface {
                 Ok(())
             },
         }
+    }
+
+    fn get_num_zones(&self) -> usize {
+        self.num_zones
     }
 }

--- a/oxcache/src/server.rs
+++ b/oxcache/src/server.rs
@@ -1,4 +1,5 @@
 use crate::cache::Cache;
+use crate::device::Device;
 use crate::eviction::{EvictionPolicyWrapper, Evictor};
 use crate::readerpool::{ReadRequest, ReaderPool};
 use crate::writerpool::{WriteRequest, WriterPool};
@@ -48,14 +49,22 @@ pub struct Server<T: RemoteBackend + Send + Sync> {
     cache: Arc<Cache>,
     config: ServerConfig,
     remote: Arc<T>,
+    device: Arc<dyn Device>,
 }
 
 impl<T: RemoteBackend + Send + Sync + 'static> Server<T> {
     pub fn new(config: ServerConfig, remote: Arc<T>) -> Result<Self, Box<dyn Error>> {
+        let device = device::get_device(
+            config.disk.as_str(),
+            config.chunk_size,
+            config.eviction.clone()
+        )?;
+
         Ok(Self {
-            cache: Arc::new(Cache::new()),
+            cache: Arc::new(Cache::new(device.get_num_zones())),
             remote,
             config,
+            device,
         })
     }
 
@@ -69,16 +78,10 @@ impl<T: RemoteBackend + Send + Sync + 'static> Server<T> {
 
         let listener = UnixListener::bind(socket_path)?;
         println!("Listening on socket: {}", self.config.socket);
-        
-        let device = device::get_device(
-            self.config.disk.as_str(),
-            self.config.chunk_size,
-            self.config.eviction.clone()
-        )?;
 
-        let evictor = Evictor::start(Arc::clone(&device));
-        let writerpool = Arc::new(WriterPool::start(self.config.writer_threads, Arc::clone(&device)));
-        let readerpool = Arc::new(ReaderPool::start(self.config.reader_threads, Arc::clone(&device)));
+        let evictor = Evictor::start(Arc::clone(&self.device));
+        let writerpool = Arc::new(WriterPool::start(self.config.writer_threads, Arc::clone(&self.device)));
+        let readerpool = Arc::new(ReaderPool::start(self.config.reader_threads, Arc::clone(&self.device)));
 
         // Shutdown signal
         let shutdown = Arc::new(Notify::new());


### PR DESCRIPTION
- Implement removing entries belonging to a zone from the map. This is done with a reverse mapping from zones to chunks. hash map now needs a num_zones parameter that indicates the number of zones, which is used for the reverse mapping.
- Added tests for hash map.
- add a get_num_zones for device to query the number of zones.
- Server also stores device now, because the hash map needs it when being constructed in server's constructor. Then when the server's run function is called, the server's reference of device is used. 