### PR TITLE
Enforce correct sizing for requests

### DIFF
--- a/oxcache/src/bin/client.rs
+++ b/oxcache/src/bin/client.rs
@@ -32,12 +32,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut reader = FramedRead::new(read_half, LengthDelimitedCodec::new());
     let mut writer = FramedWrite::new(write_half, LengthDelimitedCodec::new());
     
-    let work = vec![0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5];
-    for number in work {
+    let work = vec![
+        ("0", 0, 4096, true), ("0", 0, 4096, true),
+        ("Unaligned", 7, 4096, false),
+        ("Too large", 7, 8096, false),
+    ];
+    for req in work {
         let msg = Request::Get(GetRequest {
-            key: number.to_string(),
-            offset: number,
-            size: 4096
+            key: req.0.to_string(),
+            offset: req.1,
+            size: req.2,
         });
         
         println!("Sending: {:?}", msg);
@@ -55,7 +59,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let bytes = f.as_ref();
             let msg: Result<(request::GetResponse, usize), DecodeError> =
                 bincode::serde::decode_from_slice(bytes, bincode::config::standard());
-            println!("Received: {:?}", msg);
+            match msg?.0 {
+                (request::GetResponse::Error(s)) => {
+                    assert!(!req.3, "Expected success, recieved error {}", s);
+                },
+                (request::GetResponse::Response(_)) => {
+                    assert!(req.3, "Expected error, recieved success");
+                }
+            }
         }
 
         sleep(Duration::from_secs(2)).await;

--- a/oxcache/src/bin/client.rs
+++ b/oxcache/src/bin/client.rs
@@ -34,8 +34,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     
     let work = vec![
         ("0", 0, 4096, true), ("0", 0, 4096, true),
+        ("Aligned chunk size", 8192, 8192, true), ("Aligned chunk size", 8192, 8192, true),
         ("Unaligned", 7, 4096, false),
-        ("Too large", 7, 8096, false),
+        ("Too large", 8192, 9000, false),
     ];
     for req in work {
         let msg = Request::Get(GetRequest {

--- a/oxcache/src/cache/mod.rs
+++ b/oxcache/src/cache/mod.rs
@@ -14,14 +14,16 @@ pub mod bucket;
 #[derive(Debug)]
 pub struct Cache {
     buckets: RwLock<HashMap<Chunk, Arc<RwLock<ChunkState>>>>,
-    zone_to_entry: Mutex<Vec<Vec<Chunk>>>
+    zone_to_entry: Mutex<Vec<Vec<Chunk>>>,
+    pub chunk_size: usize,
 }
 
 impl Cache {
-    pub fn new(num_zones: usize, chunks_per_zone: usize) -> Self {
+    pub fn new(num_zones: usize, chunks_per_zone: usize, chunk_size: usize) -> Self {
         Self {
             buckets: RwLock::new(HashMap::new()),
-            zone_to_entry: Mutex::new(vec![Vec::with_capacity(chunks_per_zone); num_zones])
+            zone_to_entry: Mutex::new(vec![Vec::with_capacity(chunks_per_zone); num_zones]),
+            chunk_size
         }
     }
     
@@ -152,7 +154,7 @@ mod mod_tests {
 
     #[tokio::test]
     async fn test_insert() {
-        let cache = Cache::new(10, 100);
+        let cache = Cache::new(10, 100, 4096);
         match cache.get_or_insert_with(Chunk::new(String::from("fake-uuid"), 120, 10),
             |_| async move {
                 assert!(false, "Shouldn't reach here");
@@ -184,7 +186,7 @@ mod mod_tests {
 
     #[tokio::test]
     async fn test_insert_similar() {
-        let cache = Cache::new(10, 100);
+        let cache = Cache::new(10, 100, 4096);
 
         let fail_path = async |_: Arc<ChunkLocation>| {
             assert!(false, "Shouldn't reach here");
@@ -289,7 +291,7 @@ mod mod_tests {
 
     #[tokio::test]
     async fn test_remove() {
-        let cache = Cache::new(10, 100);
+        let cache = Cache::new(10, 100, 4096);
 
         let fail_path = async |_: Arc<ChunkLocation>| {
             assert!(false, "Shouldn't reach here");
@@ -347,7 +349,7 @@ mod mod_tests {
 
     #[tokio::test]
     async fn test_multiple_remove() {
-        let cache = Cache::new(10, 100);
+        let cache = Cache::new(10, 100, 4096);
 
         let fail_path = async |_: Arc<ChunkLocation>| {
             assert!(false, "Shouldn't reach here");

--- a/oxcache/src/cache/mod.rs
+++ b/oxcache/src/cache/mod.rs
@@ -14,16 +14,14 @@ pub mod bucket;
 #[derive(Debug)]
 pub struct Cache {
     buckets: RwLock<HashMap<Chunk, Arc<RwLock<ChunkState>>>>,
-    zone_to_entry: Mutex<Vec<Vec<Chunk>>>,
-    pub chunk_size: usize,
+    zone_to_entry: Mutex<Vec<Vec<Chunk>>>
 }
 
 impl Cache {
-    pub fn new(num_zones: usize, chunks_per_zone: usize, chunk_size: usize) -> Self {
+    pub fn new(num_zones: usize, chunks_per_zone: usize) -> Self {
         Self {
             buckets: RwLock::new(HashMap::new()),
-            zone_to_entry: Mutex::new(vec![Vec::with_capacity(chunks_per_zone); num_zones]),
-            chunk_size
+            zone_to_entry: Mutex::new(vec![Vec::with_capacity(chunks_per_zone); num_zones])
         }
     }
     
@@ -154,7 +152,7 @@ mod mod_tests {
 
     #[tokio::test]
     async fn test_insert() {
-        let cache = Cache::new(10, 100, 4096);
+        let cache = Cache::new(10, 100);
         match cache.get_or_insert_with(Chunk::new(String::from("fake-uuid"), 120, 10),
             |_| async move {
                 assert!(false, "Shouldn't reach here");
@@ -186,7 +184,7 @@ mod mod_tests {
 
     #[tokio::test]
     async fn test_insert_similar() {
-        let cache = Cache::new(10, 100, 4096);
+        let cache = Cache::new(10, 100);
 
         let fail_path = async |_: Arc<ChunkLocation>| {
             assert!(false, "Shouldn't reach here");
@@ -291,7 +289,7 @@ mod mod_tests {
 
     #[tokio::test]
     async fn test_remove() {
-        let cache = Cache::new(10, 100, 4096);
+        let cache = Cache::new(10, 100);
 
         let fail_path = async |_: Arc<ChunkLocation>| {
             assert!(false, "Shouldn't reach here");
@@ -349,7 +347,7 @@ mod mod_tests {
 
     #[tokio::test]
     async fn test_multiple_remove() {
-        let cache = Cache::new(10, 100, 4096);
+        let cache = Cache::new(10, 100);
 
         let fail_path = async |_: Arc<ChunkLocation>| {
             assert!(false, "Shouldn't reach here");

--- a/oxcache/src/main.rs
+++ b/oxcache/src/main.rs
@@ -194,13 +194,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         exit(1);
     });
     
+    let chunk_size = config.chunk_size;
+    
     match remote {
         remote::RemoteBackendType::Emulated => {
-            Server::new(config, Arc::new(remote::EmulatedBackend::new()))?.run().await?;
+            Server::new(config, Arc::new(remote::EmulatedBackend::new(chunk_size)))?.run().await?;
         },
         remote::RemoteBackendType::S3 => {
             let bucket = config.remote.bucket.clone().unwrap();
-            Server::new(config, Arc::new(remote::S3Backend::new(bucket)))?.run().await?;
+            Server::new(config, Arc::new(remote::S3Backend::new(bucket, chunk_size)))?.run().await?;
         }
     }
 

--- a/oxcache/src/remote.rs
+++ b/oxcache/src/remote.rs
@@ -7,6 +7,7 @@ use crate::server::ServerRemoteConfig;
 use async_trait::async_trait;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+use std::io::ErrorKind;
 use rand::{RngCore, SeedableRng};
 use rand_pcg::Pcg64;
 
@@ -17,47 +18,58 @@ pub trait RemoteBackend: Send + Sync {
 
 pub struct S3Backend {
     bucket: String,
+    chunk_size: usize,
 }
 
 impl S3Backend {
-    pub fn new(bucket: String) -> Self {
-        Self { bucket }
+    pub fn new(bucket: String, chunk_size: usize) -> Self {
+        Self { bucket, chunk_size }
     }
 }
 
 const EMULATED_BUFFER_SEED: u64 = 1;
-pub struct EmulatedBackend {}
+pub struct EmulatedBackend {
+    chunk_size: usize,
+}
 
 impl EmulatedBackend {
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(chunk_size: usize) -> Self {
+        Self { chunk_size}
     }
 
-    fn gen_buffer_prefix(key: &str, offset: usize, size: usize) -> Vec<u8> {
+    fn gen_buffer_prefix(buf: &mut Vec<u8>, key: &str, offset: usize, size: usize) {
         // Hash using DefaultHasher (64-bit hash)
         let mut hasher = DefaultHasher::new();
         key.hash(&mut hasher);
         let key_hash = hasher.finish(); // 8bytes
 
         // Build the buffer
-        let mut buf = Vec::with_capacity(8 + 8 + 8);
         buf.extend_from_slice(&key_hash.to_be_bytes());
         buf.extend_from_slice(&offset.to_be_bytes());
         buf.extend_from_slice(&size.to_be_bytes());
-
-        buf
     }
 
-    fn gen_random_buffer(key: &str, offset: usize, size: usize) -> tokio::io::Result<Vec<u8>> {
-        let mut buffer_prefix = Self::gen_buffer_prefix(key, offset, size);
-        let prefix_len = buffer_prefix.len();
-        if size <= prefix_len {
-            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "buffer size too small"));
+    fn gen_random_buffer(&self, key: &str, offset: usize, size: usize) -> tokio::io::Result<Vec<u8>> {
+        if size > self.chunk_size {
+            return Err(std::io::Error::new(
+                ErrorKind::InvalidInput,
+                format!("Requested size {} cannot be larger than chunk size {}", size, self.chunk_size)
+            ));
         }
+        
+        let mut buffer_prefix: Vec<u8> = Vec::with_capacity(self.chunk_size);
+        Self::gen_buffer_prefix(&mut buffer_prefix, key, offset, size);
+        let prefix_len = buffer_prefix.len();
+        if size < prefix_len {
+            return Err(std::io::Error::new(ErrorKind::InvalidInput, "buffer size too small"));
+        }
+        
         let mut rng = Pcg64::seed_from_u64(EMULATED_BUFFER_SEED);
         let mut buf = vec![0u8; size-prefix_len];
-        rng.fill_bytes(&mut buf);
+        rng.fill_bytes(&mut buf);        
         buffer_prefix.extend(buf);
+        buffer_prefix.resize(buffer_prefix.len() + (self.chunk_size - buffer_prefix.len()), 0);
+        assert_eq!(buffer_prefix.capacity(), self.chunk_size, "Expected to have capacity of {}, realloc occurred", self.chunk_size);
         Ok(buffer_prefix)
     }
 }
@@ -75,7 +87,7 @@ impl RemoteBackend for EmulatedBackend {
     async fn get(&self, key: &str, offset: usize, size: usize) -> tokio::io::Result<Vec<u8>> {
         // TODO: Implement
         println!("GET {} {} {}", key, offset, size);
-        Self::gen_random_buffer(key, offset, size)
+        self.gen_random_buffer(key, offset, size)
     }
 }
 
@@ -90,4 +102,58 @@ pub fn validated_type(remote_type: &str) -> Result<RemoteBackendType, Box<dyn st
         "s3" => Ok(RemoteBackendType::S3),
         other => Err(format!("Unknown remote type: {}", other).into()),
     }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_gen_random_buffer_correctness() {
+        let chunk_size = 128;
+        let backend = EmulatedBackend::new(chunk_size);
+
+        let key = "mykey";
+        let offset = 42;
+        let size = 100; // Less than chunk_size
+
+        let buffer = backend.gen_random_buffer(key, offset, size).unwrap();
+
+        // === Validate buffer length ===
+        assert_eq!(buffer.len(), chunk_size, "Expected buffer to be chunk_size padded");
+
+        // === Validate prefix ===
+        let mut hasher = DefaultHasher::new();
+        key.hash(&mut hasher);
+        let key_hash = hasher.finish();
+
+        let prefix_len = 8 + 8 + 8; // u64 + usize + usize, assuming 64-bit usize
+
+        let expected_prefix: Vec<u8> = [
+            &key_hash.to_be_bytes()[..],
+            &offset.to_be_bytes()[..],
+            &size.to_be_bytes()[..],
+        ].concat();
+
+        assert_eq!(&buffer[..prefix_len], &expected_prefix[..], "Prefix bytes do not match");
+
+        // === Validate random data ===
+        let mut rng = rand_pcg::Pcg64::seed_from_u64(EMULATED_BUFFER_SEED);
+        let mut expected_random = vec![0u8; size - prefix_len];
+        rng.fill_bytes(&mut expected_random);
+
+        assert_eq!(
+            &buffer[prefix_len..size],
+            &expected_random[..],
+            "Random portion of buffer does not match expected"
+        );
+
+        // === Validate padding ===
+        assert_eq!(
+            &buffer[size..],
+            vec![0u8; chunk_size - size].as_slice(),
+            "Padding bytes after size are not zero"
+        );
+    }
+
 }

--- a/oxcache/src/request.rs
+++ b/oxcache/src/request.rs
@@ -18,3 +18,61 @@ pub enum Request {
     Get(GetRequest),
     Close
 }
+
+impl GetRequest {
+    pub fn validate(&self, chunk_size: usize) -> tokio::io::Result<()> {
+        if self.offset % chunk_size != 0 {
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, format!("Offset must be aligned, recieved {}, not aligned to {}", self.offset, chunk_size)));
+        }
+        if self.size > chunk_size || self.size == 0 {
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, format!("Request size {} can not be larger than chunk size {} or smaller than 1", self.size, chunk_size)));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_get_request_validation_unaligned_offset() {
+        let req = GetRequest {
+            key: String::from("TEST"),
+            offset: 5,
+            size: 4096
+        };
+        assert!(req.validate(4096).is_err(), "Expected error for unaligned offset, recieved Ok(())")
+    }
+    #[test]
+    fn test_get_request_validation_too_large() {
+        let req = GetRequest {
+            key: String::from("TEST"),
+            offset: 0,
+            size: 8192
+        };
+        assert!(req.validate(4096).is_err(), "Expected error for size larger than chunk, recieved Ok(())")
+    }
+    
+    #[test]
+    fn test_get_request_validation_chunk_size_zero() {
+        let req = GetRequest {
+            key: String::from("TEST"),
+            offset: 0,
+            size: 0
+        };
+        assert!(req.validate(4096).is_err(), "Expected error for size 0, recieved Ok(())")
+    }
+    
+    #[test]
+    fn test_get_request_validation_match_chunk_size() {
+        let req = GetRequest {
+            key: String::from("TEST"),
+            offset: 0,
+            size: 4096
+        };
+        let res = req.validate(4096);
+        assert!(!res.is_err(), "Expected success for size larger than chunk, recieved {:?}", res)
+    }
+}


### PR DESCRIPTION
* Enforce correct sizing for requests
* The remote should return buffers aligned to chunk size
* Add testing for request validation 
* Adjust sample client to include some functional tests

These changes enforce that requests must be aligned to chunk size, the maximum request size can also not exceed chunk size. 

Still needed: Return truncated data to user so we don't need to send the entire zero padded vec