### PR TITLE
Add an evaluationclient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1965,6 +1965,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
+ "uuid",
 ]
 
 [[package]]
@@ -2969,6 +2970,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
+ "getrandom 0.3.3",
  "js-sys",
  "wasm-bindgen",
 ]

--- a/oxcache/Cargo.toml
+++ b/oxcache/Cargo.toml
@@ -23,5 +23,6 @@ rand = "0.9.1"
 rand_pcg = "0.9.0"
 flume = "0.11.1"
 lru = "0.16.0"
+uuid = { version = "1.17.0", features = ["v4"] }
 
 

--- a/oxcache/src/device.rs
+++ b/oxcache/src/device.rs
@@ -386,9 +386,13 @@ impl Device for BlockInterface {
     fn append(&self, data: Vec<u8>) -> std::io::Result<ChunkLocation> {
         let mtx = self.state.clone();
         let mut state = mtx.lock().unwrap();
+
         let chunk_location = match state.active_zones.remove_chunk_location() {
             Ok(location) => location,
             Err(()) => {
+                eprintln!(
+                    "[append] Failed to allocate chunk: no available space in active zones"
+                );
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::StorageFull,
                     "Cache is full",
@@ -397,16 +401,21 @@ impl Device for BlockInterface {
         };
         drop(state);
 
-        let mut mut_data = vec![0u8; get_aligned_buffer_size(data.len(), self.nvme_config.logical_block_size as usize)];
+        let aligned_size = get_aligned_buffer_size(data.len(), self.nvme_config.logical_block_size as usize);
+        let mut mut_data = vec![0u8; aligned_size];
         mut_data[..data.len()].copy_from_slice(&data[..]);
 
+        let write_addr = get_address_at(
+            chunk_location.zone as u64,
+            chunk_location.index,
+            (self.chunks_per_zone * self.chunk_size) as u64,
+            self.chunk_size as u64,
+        );
+        
+        // println!("[append] writing chunk to {} bytes at addr {}", chunk_location.zone, write_addr);
+
         match nvme::ops::write(
-            get_address_at(
-                chunk_location.zone as u64,
-                chunk_location.index,
-                (self.chunks_per_zone * self.chunk_size) as u64,
-                self.chunk_size as u64,
-            ),
+            write_addr,
             self.nvme_config.fd,
             0,
             self.nvme_config.nsid,
@@ -417,13 +426,25 @@ impl Device for BlockInterface {
                 let mtx = Arc::clone(&self.evict_policy);
                 let mut policy = mtx.lock().unwrap();
                 policy.write_update(ChunkLocation::new(
-                    chunk_location.zone, chunk_location.index, // addr should be in chunks
+                    chunk_location.zone,
+                    chunk_location.index,
                 ));
                 Ok(chunk_location)
-            },
-            Err(err) => Err(err.try_into().unwrap()),
+            }
+            Err(err) => {
+                // eprintln!(
+                //     "[append] nvme::ops::write failed: zone={}, index={}, addr={}, size={} bytes. Error: {:?}",
+                //     chunk_location.zone,
+                //     chunk_location.index,
+                //     write_addr,
+                //     mut_data.len(),
+                //     err
+                // );
+                Err(err.try_into().unwrap())
+            }
         }
     }
+
 
     fn read_into_buffer(
         &self,

--- a/oxcache/src/readerpool.rs
+++ b/oxcache/src/readerpool.rs
@@ -30,7 +30,7 @@ impl Reader {
     fn run(self) {
         println!("Reader {} started", self.id);
         while let Ok(msg) = self.receiver.recv() {
-            println!("Reader {} processing: {:?}", self.id, msg);
+            // println!("Reader {} processing: {:?}", self.id, msg);
             let resp = ReadResponse { data: self.device.read(msg.location) };
             let snd = msg.responder.send(resp);
             if snd.is_err() {

--- a/oxcache/src/remote.rs
+++ b/oxcache/src/remote.rs
@@ -86,7 +86,7 @@ impl RemoteBackend for S3Backend {
 impl RemoteBackend for EmulatedBackend {
     async fn get(&self, key: &str, offset: usize, size: usize) -> tokio::io::Result<Vec<u8>> {
         // TODO: Implement
-        println!("GET {} {} {}", key, offset, size);
+        // println!("GET {} {} {}", key, offset, size);
         self.gen_random_buffer(key, offset, size)
     }
 }

--- a/oxcache/src/server.rs
+++ b/oxcache/src/server.rs
@@ -191,10 +191,11 @@ async fn handle_connection<T: RemoteBackend + Send + Sync + 'static>(
                         cache.get_or_insert_with(
                             chunk.clone(),
                             {
-                                // println!("HIT {:?}", chunk);
                                 let writer = Arc::clone(&writer);
                                 let reader_pool = Arc::clone(&reader_pool);
+                                // let chunk = chunk.clone();
                                 |location| async move {
+                                    // println!("HIT {:?}", chunk);
                                     let location = location.as_ref().clone();
 
                                     let (tx, rx) = flume::bounded(1);
@@ -233,14 +234,13 @@ async fn handle_connection<T: RemoteBackend + Send + Sync + 'static>(
                                     Ok(())
                                 }
                             },
-                            {
-                                // println!("MISS {:?}", chunk);
-                                
+                            {                                
                                 let chunk = chunk.clone();
                                 let writer = Arc::clone(&writer);
                                 let remote = Arc::clone(&remote);
                                 let writer_pool = Arc::clone(&writer_pool);
                                 move || async move {
+                                    // println!("MISS {:?}", chunk);
                                     let resp = match remote.get(chunk.uuid.as_str(), chunk.offset, chunk.size).await {
                                         Ok(resp) => resp,
                                         Err(e) => {

--- a/oxcache/src/server.rs
+++ b/oxcache/src/server.rs
@@ -163,11 +163,11 @@ async fn handle_connection<T: RemoteBackend + Send + Sync + 'static>(
         let bytes = f.as_ref();
         let msg: Result<(request::Request, usize), DecodeError> =
             bincode::serde::decode_from_slice(bytes, bincode::config::standard());
-        println!("Received: {:?}", msg);
+        // println!("Received: {:?}", msg);
 
         match msg {
             Ok((request, _)) => {
-                println!("Received: {:?}", request);
+                // println!("Received: {:?}", request);
                 match request {
                     request::Request::Get(req) => {
                         if let Err(e) = req.validate(chunk_size) {
@@ -185,12 +185,13 @@ async fn handle_connection<T: RemoteBackend + Send + Sync + 'static>(
                             continue;
                         }
 
-                        println!("Received get request: {:?}", req);
+                        // println!("Received get request: {:?}", req);
                         let chunk: Chunk = req.into();
 
                         cache.get_or_insert_with(
                             chunk.clone(),
                             {
+                                // println!("HIT {:?}", chunk);
                                 let writer = Arc::clone(&writer);
                                 let reader_pool = Arc::clone(&reader_pool);
                                 |location| async move {
@@ -233,6 +234,8 @@ async fn handle_connection<T: RemoteBackend + Send + Sync + 'static>(
                                 }
                             },
                             {
+                                // println!("MISS {:?}", chunk);
+                                
                                 let chunk = chunk.clone();
                                 let writer = Arc::clone(&writer);
                                 let remote = Arc::clone(&remote);

--- a/oxcache/src/server.rs
+++ b/oxcache/src/server.rs
@@ -159,7 +159,7 @@ async fn handle_connection<T: RemoteBackend + Send + Sync + 'static>(
     let writer = Arc::new(Mutex::new(FramedWrite::new(write_half, LengthDelimitedCodec::new())));
 
     while let Some(frame) = reader.next().await {
-        let f = frame?;
+        let f = frame.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("frame read failed: {}", e)))?;
         let bytes = f.as_ref();
         let msg: Result<(request::Request, usize), DecodeError> =
             bincode::serde::decode_from_slice(bytes, bincode::config::standard());
@@ -177,68 +177,67 @@ async fn handle_connection<T: RemoteBackend + Send + Sync + 'static>(
                             ).unwrap();
                             {
                                 let mut w = writer.lock().await;
-                                w.send(Bytes::from(encoded)).await?;
+                                w.send(Bytes::from(encoded)).await.map_err(|e| {
+                                    std::io::Error::new(std::io::ErrorKind::Other, format!("failed to send validation error: {}", e))
+                                })?;
                             }
 
                             continue;
                         }
+
                         println!("Received get request: {:?}", req);
                         let chunk: Chunk = req.into();
+
                         cache.get_or_insert_with(
                             chunk.clone(),
-                            // Data was in map, read and return it
                             {
                                 let writer = Arc::clone(&writer);
                                 let reader_pool = Arc::clone(&reader_pool);
                                 |location| async move {
-                                    let location = location.as_ref().clone(); // Owned copy
-                                    // Read from disk via channel
-                                    // Proceed with writing to disk
+                                    let location = location.as_ref().clone();
+
                                     let (tx, rx) = flume::bounded(1);
                                     let read_req = ReadRequest {
                                         location,
                                         responder: tx,
                                     };
-                                    reader_pool.send(read_req).await?;
+                                    reader_pool.send(read_req).await.map_err(|e| {
+                                        std::io::Error::new(std::io::ErrorKind::Other, format!("failed to send read request: {}", e))
+                                    })?;
 
-                                    // Recieve read val
                                     let recv_err = rx.recv_async().await;
                                     let read_response = match recv_err {
-                                        Ok(wr) => {
-                                            match wr.data {
-                                                Ok(loc) => loc,
-                                                Err(e) => {
-                                                    return Err(e);
-                                                }
+                                        Ok(wr) => match wr.data {
+                                            Ok(loc) => loc,
+                                            Err(e) => {
+                                                return Err(std::io::Error::new(std::io::ErrorKind::Other, format!("read data error: {}", e)));
                                             }
                                         },
                                         Err(e) => {
-                                            eprintln!("Failed to get read response {:?}", e);
-                                            return Err(std::io::Error::new(std::io::ErrorKind::Other, recv_err.unwrap_err()));
-                                        },
+                                            return Err(std::io::Error::new(std::io::ErrorKind::Other, format!("recv_async failed for read: {}", e)));
+                                        }
                                     };
 
-                                    // Send to user
                                     let encoded = bincode::serde::encode_to_vec(
                                         request::GetResponse::Response(read_response),
                                         bincode::config::standard()
                                     ).unwrap();
                                     {
                                         let mut w = writer.lock().await;
-                                        w.send(Bytes::from(encoded)).await?;
+                                        w.send(Bytes::from(encoded)).await.map_err(|e| {
+                                            std::io::Error::new(std::io::ErrorKind::Other, format!("failed to send read response: {}", e))
+                                        })?;
                                     }
-                                    
+
                                     Ok(())
                                 }
                             },
-                            // Data wasn't in map, request it and write it
                             {
                                 let chunk = chunk.clone();
                                 let writer = Arc::clone(&writer);
                                 let remote = Arc::clone(&remote);
                                 let writer_pool = Arc::clone(&writer_pool);
                                 move || async move {
-                                    // Call remote (S3, ...)
                                     let resp = match remote.get(chunk.uuid.as_str(), chunk.offset, chunk.size).await {
                                         Ok(resp) => resp,
                                         Err(e) => {
@@ -248,51 +247,50 @@ async fn handle_connection<T: RemoteBackend + Send + Sync + 'static>(
                                             ).unwrap();
                                             {
                                                 let mut w = writer.lock().await;
-                                                w.send(Bytes::from(encoded)).await?;
+                                                w.send(Bytes::from(encoded)).await.map_err(|e| {
+                                                    std::io::Error::new(std::io::ErrorKind::Other, format!("failed to send remote error response: {}", e))
+                                                })?;
                                             }
-                                            // Fatal error, or keep accepting? Currently fatal, closes connection.
-                                            return Err(e);
+                                            return Err(std::io::Error::new(std::io::ErrorKind::Other, format!("remote.get failed: {}", e)));
                                         }
                                     };
-                                    
-                                    // Send to user
+
                                     let encoded = bincode::serde::encode_to_vec(
                                         request::GetResponse::Response(resp.clone()),
                                         bincode::config::standard()
                                     ).unwrap();
                                     {
                                         let mut w = writer.lock().await;
-                                        w.send(Bytes::from(encoded)).await?;
+                                        w.send(Bytes::from(encoded)).await.map_err(|e| {
+                                            std::io::Error::new(std::io::ErrorKind::Other, format!("failed to send remote get response: {}", e))
+                                        })?;
                                     }
 
-                                    // Proceed with writing to disk
                                     let (tx, rx) = flume::bounded(1);
                                     let write_req = WriteRequest {
                                         data: resp,
                                         responder: tx,
                                     };
-                                    writer_pool.send(write_req).await?;
+                                    writer_pool.send(write_req).await.map_err(|e| {
+                                        std::io::Error::new(std::io::ErrorKind::Other, format!("failed to send write request: {}", e))
+                                    })?;
 
-                                    // Recieve written val
                                     let recv_err = rx.recv_async().await;
                                     let write_response = match recv_err {
-                                        Ok(wr) => {
-                                            match wr.location {
-                                                Ok(loc) => loc,
-                                                Err(e) => {
-                                                    return Err(e);
-                                                }
+                                        Ok(wr) => match wr.location {
+                                            Ok(loc) => loc,
+                                            Err(e) => {
+                                                return Err(std::io::Error::new(std::io::ErrorKind::Other, format!("write location error: {}", e)));
                                             }
                                         },
                                         Err(e) => {
-                                            eprintln!("Failed to get write response {:?}", e);
-                                            return Err(std::io::Error::new(std::io::ErrorKind::Other, recv_err.unwrap_err()));
-                                        },
+                                            return Err(std::io::Error::new(std::io::ErrorKind::Other, format!("recv_async failed for write: {}", e)));
+                                        }
                                     };
                                     Ok(write_response)
                                 }
                             },
-                        ).await?;                        
+                        ).await.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("cache.get_or_insert_with failed: {}", e)))?;
                     }
                     request::Request::Close => {
                         println!("Received close request");

--- a/oxcache/src/writerpool.rs
+++ b/oxcache/src/writerpool.rs
@@ -33,7 +33,7 @@ impl Writer {
     fn run(self) {
         println!("Writer {} started", self.id);
         while let Ok(msg) = self.receiver.recv() {
-            println!("Writer {} processing: {:?}", self.id, msg);
+            // println!("Writer {} processing: {:?}", self.id, msg);
             let resp = WriteResponse { location: self.device.append(msg.data) };
             let snd = msg.responder.send(resp);
             if snd.is_err() {


### PR DESCRIPTION
Client supports arbitrary number of green threads used to query the cache selected via the socket parameter. 

Eventually this will read from a file for the workload