### PR TITLE
Metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2373,6 +2373,7 @@ dependencies = [
  "libnvme-sys",
  "log",
  "lru 0.16.0",
+ "metrics",
  "metrics-exporter-prometheus",
  "ndarray",
  "nvme",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,7 +588,11 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
+ "tokio",
  "tower 0.4.13",
  "tower-layer",
  "tower-service",
@@ -625,6 +641,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64-simd"
@@ -1020,6 +1042,15 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1532,7 +1563,7 @@ version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "byteorder",
  "flate2",
  "nom",
@@ -1680,6 +1711,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1879,6 +1911,12 @@ dependencies = [
  "equivalent",
  "hashbrown 0.15.3",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2098,6 +2136,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "metrics"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25dea7ac8057892855ec285c440160265225438c3c45072613c25a4b26e98ef5"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b166dea96003ee2531cf14833efedced545751d800f03535801d833313f8c15"
+dependencies = [
+ "base64 0.22.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.6",
+ "hyper-util",
+ "indexmap 2.9.0",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe8db7a05415d0f919ffb905afa37784f71901c9a773188876984b4f769ab986"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.3",
+ "metrics",
+ "quanta",
+ "rand 0.9.1",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2274,6 +2359,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-s3",
+ "axum",
  "bincode",
  "byteorder",
  "bytes",
@@ -2287,6 +2373,7 @@ dependencies = [
  "libnvme-sys",
  "log",
  "lru 0.16.0",
+ "metrics-exporter-prometheus",
  "ndarray",
  "nvme",
  "once_cell",
@@ -2514,6 +2601,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2594,6 +2696,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b48ac3f7ffaab7fac4d2376632268aa5f89abdb55f7ebf8f4d11fffccb2320f7"
 dependencies = [
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
+dependencies = [
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -2692,7 +2812,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bitflags 2.9.1",
  "serde",
  "serde_derive",
@@ -2805,7 +2925,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -2965,11 +3085,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -3028,6 +3170,12 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
 
 [[package]]
 name = "slab"
@@ -3340,7 +3488,7 @@ checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.21.7",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3408,6 +3556,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3655,6 +3804,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/cortes.server.block.toml
+++ b/cortes.server.block.toml
@@ -19,3 +19,7 @@ eviction_policy = "promotional"
 high_water_evict = 1 # Number remaining from end, evicts if reaches here
 low_water_evict = 3  # Evict until below mark
 eviction_interval = 1  # Evict every 1s
+
+[metrics]
+ip_addr = "127.0.0.1"
+port = 9000

--- a/cortes.server.zns.toml
+++ b/cortes.server.zns.toml
@@ -19,3 +19,7 @@ eviction_policy = "promotional"
 high_water_evict = 1 # Number remaining from end, evicts if reaches here
 low_water_evict = 3  # Evict until below mark
 eviction_interval = 1  # Evict every 1s
+
+[metrics]
+ip_addr = "127.0.0.1"
+port = 9000

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: oxcache-prometheus
+    network_mode: host
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    restart: unless-stopped

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 1s
+  evaluation_interval: 1s
+
+scrape_configs:
+  - job_name: "oxcache"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: ["localhost:9000"]

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -1,0 +1,41 @@
+# Metrics
+
+Metrics are optionally exposed to Prometheus.
+
+To set up a container with docker compose run:
+
+``` 
+cd docker 
+docker compose up -d 
+``` 
+
+Prometheus should now be exposed at: http://127.0.0.1:9090
+
+If this is on a remote server you can SSH tunnel with (eg cortes):
+
+```
+ssh -L 12344:127.0.0.1:9090 cortes
+``` 
+
+Then you can locally visit http://127.0.0.1:12344/query
+
+By default this expects metrics to be exposed to the prometheus at port 9000 (set in prometheus.yml), make sure to set the appropriate port and IP address in OxCache configuration:
+
+```toml
+[metrics]
+ip_addr = "127.0.0.1"
+port = 9000 
+``` 
+
+Now running the server metrics should start being collected. On each individual start of the server it sets a new "run_id", set to the Unix timestamp from when the server started. This can be used to distinguish individual runs.
+
+## Metrics
+
+Various metrics are being exposed, and will be completed if you start typing `oxcache_`. You can use promql queries to determine throughput based on the read/written totals:
+
+``` 
+rate(oxcache_written_bytes_total[1m]) 
+rate(oxcache_read_bytes_total[1m])
+``` 
+
+Time frame can be adjusted to modify the binning

--- a/example.server.toml
+++ b/example.server.toml
@@ -19,3 +19,7 @@ eviction_policy = "promotional"
 high_water_evict = 5 # Number remaining from end, evicts if reaches here
 low_water_evict = 7  # Evict until below mark
 eviction_interval = 1  # Evict every 1s
+
+[metrics]
+ip_addr = "127.0.0.1"
+port = 9000

--- a/oxcache/Cargo.toml
+++ b/oxcache/Cargo.toml
@@ -34,4 +34,5 @@ log = "0.4"
 env_logger = "0.11"
 metrics-exporter-prometheus = "0.17.2"
 axum = "0.6.20"
+metrics = "0.24.2"
 

--- a/oxcache/Cargo.toml
+++ b/oxcache/Cargo.toml
@@ -32,4 +32,6 @@ console-subscriber = "0.1"
 tracing-subscriber = "0.3"
 log = "0.4"
 env_logger = "0.11"
+metrics-exporter-prometheus = "0.17.2"
+axum = "0.6.20"
 

--- a/oxcache/src/lib.rs
+++ b/oxcache/src/lib.rs
@@ -8,3 +8,4 @@ pub mod server;
 pub mod util;
 pub mod writerpool;
 pub mod zone_state;
+mod metrics;

--- a/oxcache/src/metrics.rs
+++ b/oxcache/src/metrics.rs
@@ -1,6 +1,14 @@
 use axum::{routing::get, Router};
 use metrics_exporter_prometheus::PrometheusBuilder;
 use std::net::{IpAddr, SocketAddr};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use metrics::{counter, gauge, histogram};
+use once_cell::sync::Lazy;
+
+pub static METRICS: Lazy<MetricsRecorder> = Lazy::new(|| {
+    MetricsRecorder::new()
+});
 
 pub fn init_metrics_exporter(addr: SocketAddr) {
     let builder = PrometheusBuilder::new();
@@ -20,3 +28,47 @@ pub fn init_metrics_exporter(addr: SocketAddr) {
             .expect("failed to start metrics server");
     });
 }
+
+pub struct MetricsRecorder {
+    run_id: String,
+    prefix: String,
+}
+
+pub enum MetricType {
+    MsLatency
+}
+
+const MILLISECONDS: f64 = 1_000.0;
+
+impl MetricsRecorder {
+    pub fn new() -> Self {
+        let now = SystemTime::now();
+        let since_epoch = now.duration_since(UNIX_EPOCH).unwrap();
+
+        Self {
+            run_id: since_epoch.as_secs().to_string(),
+            prefix: String::from("oxcache"),
+        }
+    }
+    pub fn update_metric_histogram_latency(&self, name: &str, value: Duration, metric_type: MetricType) {
+        let id = self.run_id.clone();
+        let h = histogram!(format!("{}_{}", self.prefix, name.to_string()), "run_id" => id.clone());
+        let v = match metric_type {
+            MetricType::MsLatency => {
+                value.as_secs_f64() * MILLISECONDS
+            },
+            _ => {
+                log::warn!("Unknown metric type");
+                return;
+            },
+        };
+        h.record(v);
+    }
+
+    pub fn update_metric_counter(&self, name: &str, value: u64) {
+        let id = self.run_id.clone();
+        let h = counter!(format!("{}_{}", self.prefix, name.to_string()), "run_id" => id.clone());
+        h.increment(value);
+    }
+}
+

--- a/oxcache/src/metrics.rs
+++ b/oxcache/src/metrics.rs
@@ -1,0 +1,22 @@
+use axum::{routing::get, Router};
+use metrics_exporter_prometheus::PrometheusBuilder;
+use std::net::{IpAddr, SocketAddr};
+
+pub fn init_metrics_exporter(addr: SocketAddr) {
+    let builder = PrometheusBuilder::new();
+    let recorder_handle = builder.install_recorder().expect("failed to install recorder");
+
+    // Spawn HTTP server in a tokio task (green thread)
+    tokio::spawn(async move {
+        let app = Router::new().route("/metrics", get(move || async move {
+            recorder_handle.render()
+        }));
+
+        log::info!("Serving metrics at http://{}/metrics", addr);
+
+        axum::Server::bind(&addr)
+            .serve(app.into_make_service())
+            .await
+            .expect("failed to start metrics server");
+    });
+}


### PR DESCRIPTION
Initial work for adding metrics. 

What has been done is we now have a Prometheus exporter displaying certain metrics. See `docs/METRICS.md`. 

Alongside the Prometheus exported data I also want to export individual data points in CSV for plotting. This can use the same functions that we're using for prometheus. 

To add an additional metric just call one of the two functions. Currently I have one for latency and one that is just a counter that we can use for throughput or just counting: 

https://github.com/johnramsden/OxCache/blob/5856677dc33ea3ca01ba58fafb74b1a6d42edc6a/oxcache/src/metrics.rs#L53-L72